### PR TITLE
Ignore unexported fields

### DIFF
--- a/entity_parser.go
+++ b/entity_parser.go
@@ -140,6 +140,9 @@ func TableFromInstance(object DomainObject) (*Table, error) {
 	}
 	for i := 0; i < elem.NumField(); i++ {
 		structField := elem.Field(i)
+		if len(structField.PkgPath) > 0 { // skip unexported fields
+			continue
+		}
 		name := structField.Name
 		if name == entityName {
 			if t.Key, err = parseEntityTag(structField, t.StructName); err != nil {

--- a/entity_parser_test.go
+++ b/entity_parser_test.go
@@ -25,6 +25,8 @@ import (
 
 	"time"
 
+	"io"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -265,4 +267,20 @@ func TestKeyFieldNameTypo(t *testing.T) {
 	assert.Nil(t, dosaTable)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "BoolHype")
+}
+
+func TestIgnoreUnexportedFields(t *testing.T) {
+	type UnexportedFieldType struct {
+		Entity          `dosa:"primaryKey=BoolType"`
+		BoolType        bool
+		unexported      string
+		unsupportedType io.Reader
+	}
+
+	table, err := TableFromInstance(&UnexportedFieldType{})
+	assert.NoError(t, err)
+	assert.Len(t, table.FieldNames, 1)
+	assert.NotContains(t, table.FieldNames, "unexported")
+	assert.NotContains(t, table.FieldNames, "unsupportedType")
+	assert.Len(t, table.Columns, 1)
 }


### PR DESCRIPTION
Unexported Fields cannot be set with reflect in deserialization, so they are ignored following golang json's convention.