### PR TITLE
Re-add make gendoc to lint checks

### DIFF
--- a/.build/lint.mk
+++ b/.build/lint.mk
@@ -29,4 +29,7 @@ lint: vendor
 	$(ECHO_V)git grep -i fixme | grep -v -e $(_THIS_MAKEFILE) -e CONTRIBUTING.md | tee -a $(LINT_LOG)
 	@echo "Checking for imports of log package"
 	$(ECHO_V)go list -f '{{ .ImportPath }}: {{ .Imports }}' $(shell glide nv) | grep -e "\blog\b" | tee -a $(LINT_LOG)
+	@echo "Ensuring generated doc.go are up to date"
+	$(ECHO_V)$(MAKE) gendoc
+	$(ECHO_V)[ -z "$(shell git status --porcelain | grep '\bdoc.go$$')" ] || echo "Commit updated doc.go changes" | tee -a $(LINT_LOG)
 	$(ECHO_V)[ ! -s $(LINT_LOG) ]


### PR DESCRIPTION
Follow up to #31 and #34. I forgot to re-add `make gendoc` to the lint rules.