### PR TITLE
Tweak fmt target to run both gofmt and goimports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,7 @@ vendor:
 .PHONY: fmt
 GOIMPORTS=goimports
 fmt:
-ifeq (, $(shell command -v $(GOIMPORTS) 2> /dev/null))
-				$(ECHO_V)gofmt -w $(ALL_SRC)
-else
+				$(ECHO_V)gofmt -s -w $(ALL_SRC)
+ifneq (, $(shell command -v $(GOIMPORTS) 2> /dev/null))
 				$(ECHO_V)$(GOIMPORTS) -w $(ALL_SRC)
 endif


### PR DESCRIPTION
gofmt has "-s" (simplify code) option, which is missing in goimports. So make it run both.