### PR TITLE
Force goimports to exist on local machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ vendor:
 .PHONY: fmt
 GOIMPORTS=goimports
 fmt:
-				$(ECHO_V)gofmt -s -w $(ALL_SRC)
-ifneq (, $(shell command -v $(GOIMPORTS) 2> /dev/null))
-				$(ECHO_V)$(GOIMPORTS) -w $(ALL_SRC)
-endif
+	$(ECHO_V)gofmt -s -w $(ALL_SRC)
+	$(ECHO_V)if [ "$$TRAVIS" != "true" ]; then \
+		$(GOIMPORTS) -w $(ALL_SRC) ; \
+	fi


### PR DESCRIPTION
If running on travis, just skip this step. This avoids the
problem of not having goimports on your path while developing
and checking things in with the imports wrong.