### PR TITLE
Implement client side ScanEverything

### DIFF
--- a/client_local_test.go
+++ b/client_local_test.go
@@ -1,0 +1,13 @@
+package dosa
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+// just for 100% coverage. This belongs in client_test but can't since
+// it requires calling a private method
+func TestIsDomainObject(t *testing.T) {
+	e := &Entity{}
+	assert.True(t, e.isDomainObject())
+}

--- a/finder_test.go
+++ b/finder_test.go
@@ -59,7 +59,7 @@ func TestParser(t *testing.T) {
 	assert := assert.New(t)
 
 	assert.Equal(13, len(entities), fmt.Sprintf("%s", entities))
-	assert.Equal(12, len(errs), fmt.Sprintf("%s", err))
+	assert.Equal(13, len(errs), fmt.Sprintf("%s", err))
 	assert.Nil(err)
 
 	for _, entity := range entities {

--- a/range.go
+++ b/range.go
@@ -29,16 +29,13 @@ import (
 
 // RangeOp is used to specify constraints to Range calls
 type RangeOp struct {
-	object        DomainObject
-	conditions    map[string][]*Condition
-	fieldsToFetch []string
-	limit         int
-	token         string
+	sop        ScanOp
+	conditions map[string][]*Condition
 }
 
 // NewRangeOp returns a new RangeOp instance
 func NewRangeOp(object DomainObject) *RangeOp {
-	rop := &RangeOp{conditions: map[string][]*Condition{}, object: object}
+	rop := &RangeOp{conditions: map[string][]*Condition{}, sop: ScanOp{object: object}}
 	return rop
 }
 
@@ -69,12 +66,7 @@ func (r *RangeOp) String() string {
 			}
 		}
 	}
-	if r.limit > 0 {
-		fmt.Fprintf(result, " limit %d", r.limit)
-	}
-	if r.token != "" {
-		fmt.Fprintf(result, " token %q", r.token)
-	}
+	addLimitTokenString(result, r.sop.limit, r.sop.token)
 	return result.String()
 }
 
@@ -112,21 +104,21 @@ func (r *RangeOp) LtOrEq(fieldName string, value interface{}) *RangeOp {
 
 // Fields list the non-key fields users want to fetch. If not set, all fields would be fetched.
 // PrimaryKey fields are always fetched.
-func (r *RangeOp) Fields(fieldsToFetch []string) *RangeOp {
-	r.fieldsToFetch = fieldsToFetch
+func (r *RangeOp) Fields(fieldsToRead []string) *RangeOp {
+	r.sop.fieldsToRead = fieldsToRead
 	return r
 }
 
 // Limit sets the number of rows returned per call. If not set, a default
 // value would be applied
 func (r *RangeOp) Limit(n int) *RangeOp {
-	r.limit = n
+	r.sop.limit = n
 	return r
 }
 
 // Offset sets the pagination token. If not set, an empty token would be used.
 func (r *RangeOp) Offset(token string) *RangeOp {
-	r.token = token
+	r.sop.token = token
 	return r
 }
 

--- a/registry_test.go
+++ b/registry_test.go
@@ -136,8 +136,8 @@ func TestRegisteredEntity_SetFieldValues(t *testing.T) {
 		"email": "bar@email.com",
 	}
 	invalidFieldValues := map[string]dosa.FieldValue{
-		"id":      int64(2),
-		"name":    "bar",
+		"id":      int64(3),
+		"name":    "bar2",
 		"invalid": "invalid",
 	}
 
@@ -146,11 +146,14 @@ func TestRegisteredEntity_SetFieldValues(t *testing.T) {
 		re.SetFieldValues(&RegistryTestInvalid{PrimaryKey: 1}, validFieldValues)
 	})
 
-	// invalid values
-	assert.Error(t, re.SetFieldValues(entity, invalidFieldValues))
+	// invalid values are skipped
+	re.SetFieldValues(entity, invalidFieldValues)
+	assert.Equal(t, entity.ID, invalidFieldValues["id"])
+	assert.Equal(t, entity.Name, invalidFieldValues["name"])
+	assert.Equal(t, entity.Email, "foo@email.com")
 
 	// valid
-	assert.NoError(t, re.SetFieldValues(entity, validFieldValues))
+	re.SetFieldValues(entity, validFieldValues)
 	assert.Equal(t, entity.ID, validFieldValues["id"])
 	assert.Equal(t, entity.Name, validFieldValues["name"])
 	assert.Equal(t, entity.Email, validFieldValues["email"])

--- a/scan.go
+++ b/scan.go
@@ -20,35 +20,57 @@
 
 package dosa
 
+import (
+	"fmt"
+	"io"
+	"bytes"
+)
+
 // ScanOp represents the scan query
-type ScanOp struct{}
+type ScanOp struct {
+	object       DomainObject
+	limit        int
+	token        string
+	fieldsToRead []string
+}
 
 // NewScanOp returns a new ScanOp instance
-func NewScanOp(DomainObject) *ScanOp {
-	return &ScanOp{}
+func NewScanOp(obj DomainObject) *ScanOp {
+	return &ScanOp{object: obj}
 }
 
 // String satisfies the Stringer interface
 func (s *ScanOp) String() string {
-	/* TODO */
-	return ""
+	result := &bytes.Buffer{}
+	result.WriteString("ScanOp")
+	addLimitTokenString(result, s.limit, s.token)
+	return result.String()
+}
+
+func addLimitTokenString(w io.Writer, limit int, token string) {
+	if limit > 0 {
+		fmt.Fprintf(w, " limit %d", limit)
+	}
+	if token != "" {
+		fmt.Fprintf(w, " token %q", token)
+	}
 }
 
 // Limit sets the number of rows returned per call. Default is 128.
 func (s *ScanOp) Limit(n int) *ScanOp {
-	/* TODO */
+	s.limit = n
 	return s
 }
 
 // Offset sets the pagination token. If not set, an empty token would be used.
 func (s *ScanOp) Offset(token string) *ScanOp {
-	/* TODO */
+	s.token = token
 	return s
 }
 
 // Fields list the non-key fields users want to fetch.
 // PrimaryKey fields are always fetched.
-func (s *ScanOp) Fields([]string) *ScanOp {
-	/* TODO */
+func (s *ScanOp) Fields(fields []string) *ScanOp {
+	s.fieldsToRead = fields
 	return s
 }

--- a/scan_test.go
+++ b/scan_test.go
@@ -26,13 +26,56 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/uber-go/dosa"
+	"time"
 )
+
+type AllTypes struct {
+	dosa.Entity `dosa:"primaryKey=BoolType"`
+	BoolType    bool
+	Int32Type   int32
+	Int64Type   int64
+	DoubleType  float64
+	StringType  string
+	BlobType    []byte
+	TimeType    time.Time
+	UUIDType    dosa.UUID
+}
 
 func TestNewScanOp(t *testing.T) {
 	assert.NotNil(t, dosa.NewScanOp(&dosa.Entity{}))
 }
 
 func TestScanOpStringer(t *testing.T) {
-	o := dosa.NewScanOp(&dosa.Entity{})
-	assert.Equal(t, "", o.String())
+	for _, test := range ScanTestCases {
+		assert.Equal(t, test.stringer, test.sop.String(), test.descript)
+	}
+}
+
+var ScanTestCases = []struct {
+	descript  string
+	sop       *dosa.ScanOp
+	stringer  string
+	converted string
+	err       string
+}{
+	{
+		descript: "empty scanop, valid",
+		sop:      dosa.NewScanOp(&AllTypes{}),
+		stringer: "ScanOp",
+	},
+	{
+		descript: "empty with limit",
+		sop:      dosa.NewScanOp(&AllTypes{}).Limit(10),
+		stringer: "ScanOp limit 10",
+	},
+	{
+		descript: "empty with token",
+		sop:      dosa.NewScanOp(&AllTypes{}).Offset("toketoketoke"),
+		stringer: "ScanOp token \"toketoketoke\"",
+	},
+	{
+		descript: "with valid field list",
+		sop:      dosa.NewScanOp(&AllTypes{}).Fields([]string{"StringType"}),
+		stringer: "ScanOp",
+	},
 }


### PR DESCRIPTION
This code adapts the client's ScanEverything call to the
connector's Scan call.

The ScanOp is now a subset of the RangeOp type. It's
unfortunate that it couldn't be an anonymous member but
it won't work correctly with private fields.

There are some additional fixes in this diff:
 * Improve client_test.go, now back at 100% coverage
 * Skip fields that are unknown but returned by the server
 * Stop returning errors from methods that can't possibly error
   unless there is an internal problem. These will now panic.