### PR TITLE
Implement client CheckSchema

### DIFF
--- a/cli/cmd/schema.go
+++ b/cli/cmd/schema.go
@@ -174,7 +174,7 @@ func expandDirectories(dirs []string) ([]string, error) {
 func findEntities(dirs []string, exclude string, pedantic bool) ([]*dosa.Table, error) {
 	entities := make([]*dosa.Table, 0)
 	for _, dir := range dirs {
-		ents, errs, err := dosa.FindEntities(dir, exclude)
+		ents, errs, err := dosa.FindEntities(dir, []string{exclude})
 		if err != nil {
 			fmt.Fprint(os.Stderr, err)
 			return nil, err

--- a/finder.go
+++ b/finder.go
@@ -37,14 +37,18 @@ import (
 
 // FindEntities finds all entities in a directory
 // Returns a slice of warnings (or nil)
-func FindEntities(path string, excludes string) ([]*Table, []error, error) {
+func FindEntities(path string, excludes []string) ([]*Table, []error, error) {
 	fileSet := token.NewFileSet()
 	packages, err := parser.ParseDir(fileSet, path, func(fileInfo os.FileInfo) bool {
-		if excludes == "" {
+		if len(excludes) == 0 {
 			return true
 		}
-		matched, _ := filepath.Match(excludes, fileInfo.Name())
-		return !matched
+		for _, exclude := range excludes {
+			if matched, _ := filepath.Match(exclude, fileInfo.Name()); matched {
+				return false
+			}
+		}
+		return true
 	}, 0)
 	if err != nil {
 		return nil, nil, err

--- a/finder_test.go
+++ b/finder_test.go
@@ -30,7 +30,6 @@ import (
 )
 
 func TestUnparseableGoCode(t *testing.T) {
-	assert := assert.New(t)
 	const tmpdir = ".testgen"
 	defer os.RemoveAll(tmpdir)
 	if err := os.Mkdir(tmpdir, 0770); err != nil {
@@ -39,28 +38,25 @@ func TestUnparseableGoCode(t *testing.T) {
 	if err := ioutil.WriteFile(tmpdir+"/broken.go", []byte("package broken\nfunc broken\n"), 0644); err != nil {
 		t.Fatalf("can't create %s/broken.go: %s", tmpdir, err)
 	}
-	entities, errs, err := FindEntities(tmpdir, "")
-	assert.Nil(entities)
-	assert.Nil(errs)
-	assert.Contains(err.Error(), "expected '('")
+	entities, errs, err := FindEntities(tmpdir, []string{})
+	assert.Nil(t, entities)
+	assert.Nil(t, errs)
+	assert.Contains(t, err.Error(), "expected '('")
 }
 
 func TestNonExistentDirectory(t *testing.T) {
 	const nonExistentDirectory = "ThisDirectoryBetterNotExist"
-	entities, errs, err := FindEntities(nonExistentDirectory, "")
-	assert := assert.New(t)
-	assert.Nil(entities)
-	assert.Nil(errs)
-	assert.Contains(err.Error(), nonExistentDirectory)
+	entities, errs, err := FindEntities(nonExistentDirectory, []string{})
+	assert.Nil(t, entities)
+	assert.Nil(t, errs)
+	assert.Contains(t, err.Error(), nonExistentDirectory)
 }
 
 func TestParser(t *testing.T) {
-	entities, errs, err := FindEntities(".", "")
-	assert := assert.New(t)
-
-	assert.Equal(13, len(entities), fmt.Sprintf("%s", entities))
-	assert.Equal(14, len(errs), fmt.Sprintf("%v", errs))
-	assert.Nil(err)
+	entities, errs, err := FindEntities(".", []string{})
+	assert.Equal(t, 13, len(entities), fmt.Sprintf("%s", entities))
+	assert.Equal(t, 14, len(errs), fmt.Sprintf("%v", errs))
+	assert.Nil(t, err)
 
 	for _, entity := range entities {
 		var e *Table
@@ -95,20 +91,19 @@ func TestParser(t *testing.T) {
 			t.Errorf("entity %s not expected", entity.Name)
 			continue
 		}
-		assert.Equal(e, entity)
+		assert.Equal(t, e, entity)
 	}
 }
 
 func TestExclusion(t *testing.T) {
-	entities, errs, err := FindEntities(".", "*_test.go")
-	assert := assert.New(t)
-	assert.Equal(0, len(entities))
-	assert.Equal(0, len(errs))
-	assert.Nil(err)
+	entities, errs, err := FindEntities(".", []string{"*_test.go"})
+	assert.Equal(t, 0, len(entities))
+	assert.Equal(t, 0, len(errs))
+	assert.Nil(t, err)
 }
 
 func BenchmarkFinder(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		FindEntities(".", "")
+		FindEntities(".", []string{})
 	}
 }


### PR DESCRIPTION
This implements the client-side of `CheckSchema`. In doing so, I chose to change the `dosa.AdminClient` interface to not use the `dosa.FQN` type since it doesn't make much sense any more. 

ALSO, I changed `dosa.FindEntities` to take a list of excluded patterns rather than just a single per invocation.