### PR TITLE
Allow override of disallowed struct names

### DIFF
--- a/entity_parser_test.go
+++ b/entity_parser_test.go
@@ -362,17 +362,27 @@ func TestRenameToInvalidName(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid name tag: name=ABădNăme")
 }
 
-type BadNameButRenamed struct {
+type BadColNameButRenamed struct {
 	Entity   `dosa:"primaryKey=(ABădNăme)"`
 	ABădNăme bool `dosa:"name=goodname"`
 }
 
-func TestRenameToValidName(t *testing.T) {
-	table, err := TableFromInstance(&BadNameButRenamed{})
+func TestRenameColumnToValidName(t *testing.T) {
+	table, err := TableFromInstance(&BadColNameButRenamed{})
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"goodname"}, table.Key.PartitionKeys)
 }
 
 type StructWithUnannotatedEntity struct {
 	Entity `notdosa:"covers a rare test case"`
+}
+
+func TestRenameStructToValidName(t *testing.T) {
+	type ABădNăme struct {
+		Entity `dosa:"name=agoodname,primaryKey=Dummy"`
+		Dummy  bool
+	}
+	table, err := TableFromInstance(&ABădNăme{})
+	assert.NotNil(t, table)
+	assert.NoError(t, err)
 }

--- a/finder_test.go
+++ b/finder_test.go
@@ -59,7 +59,7 @@ func TestParser(t *testing.T) {
 	assert := assert.New(t)
 
 	assert.Equal(13, len(entities), fmt.Sprintf("%s", entities))
-	assert.Equal(13, len(errs), fmt.Sprintf("%s", err))
+	assert.Equal(14, len(errs), fmt.Sprintf("%v", errs))
 	assert.Nil(err)
 
 	for _, entity := range entities {
@@ -83,8 +83,8 @@ func TestParser(t *testing.T) {
 			e, _ = TableFromInstance(&UnexportedFieldType{})
 		case "ignoretagtype":
 			e, _ = TableFromInstance(&IgnoreTagType{})
-		case "badnamebutrenamed":
-			e, _ = TableFromInstance(&BadNameButRenamed{})
+		case "badcolnamebutrenamed":
+			e, _ = TableFromInstance(&BadColNameButRenamed{})
 		case "clienttestentity1": // skip, see https://jira.uberinternal.com/browse/DOSA-788
 			continue
 		case "clienttestentity2": // skip, same as above


### PR DESCRIPTION
This change allows you to specify a name= attribute
overriding an auto-generated invalid entity table name.