### PR TITLE
Expand empty column lists

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -162,10 +162,11 @@ func TestClient_Read_Errors(t *testing.T) {
 	defer ctrl.Finish()
 	readError := errors.New("oops")
 	mockConn := mocks.NewMockConnector(ctrl)
-	mockConn.EXPECT().CheckSchema(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]int32{1}, nil).AnyTimes()
-	mockConn.EXPECT().Read(gomock.Any(), gomock.Any(), gomock.Any(), dosa.All()).
+	mockConn.EXPECT().CheckSchema(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return([]int32{1}, nil).AnyTimes()
+	mockConn.EXPECT().Read(ctx, gomock.Any(), gomock.Any(), gomock.Any()).
 		Do(func(_ context.Context, _ *dosa.EntityInfo, columnValues map[string]dosa.FieldValue, columnsToRead []string) {
 			assert.Equal(t, columnValues["id"], cte1.ID)
+			assert.NotEmpty(t, columnsToRead)
 		}).Return(nil, readError)
 
 	c1 := dosa.NewClient(reg1, mockConn)

--- a/registry.go
+++ b/registry.go
@@ -115,9 +115,10 @@ func (e *RegisteredEntity) KeyFieldValues(entity DomainObject) map[string]FieldV
 // a subset of fields. If a field name provided does not map to an entity
 // field, an error will be returned.
 func (e *RegisteredEntity) OnlyFieldValues(entity DomainObject, fieldNames []string) (map[string]FieldValue, error) {
-	// empty should return error
-	if len(fieldNames) == 0 {
-		return nil, fmt.Errorf("Cannot provide empty list to OnlyFieldValues")
+	if fieldNames == nil || len(fieldNames) == 0 {
+		for _, field := range e.table.ColToField {
+			fieldNames = append(fieldNames, field)
+		}
 	}
 	v := reflect.ValueOf(entity).Elem()
 	fieldValues := make(map[string]FieldValue)
@@ -139,8 +140,10 @@ func (e *RegisteredEntity) OnlyFieldValues(entity DomainObject, fieldNames []str
 
 // ColumnNames translates field names to column names.
 func (e *RegisteredEntity) ColumnNames(fieldNames []string) ([]string, error) {
-	if fieldNames == nil {
-		return nil, nil
+	if fieldNames == nil || len(fieldNames) == 0 {
+		for _, field := range e.table.ColToField {
+			fieldNames = append(fieldNames, field)
+		}
 	}
 	columnNames := make([]string, len(fieldNames))
 	for i, fieldName := range fieldNames {


### PR DESCRIPTION
Empty or nil lists now expand to all columns on
the client, so the connector will always see the
whole list of known columns on the client