### PR TITLE
Use CallerName instead of ServiceName when setting up raw TChannel

### DIFF
--- a/connectors/yarpc/yarpc.go
+++ b/connectors/yarpc/yarpc.go
@@ -87,6 +87,9 @@ func NewConnector(cfg *Config) (*Connector, error) {
 		}
 	case "tchannel":
 		hostPort := fmt.Sprintf("%s:%s", cfg.Host, cfg.Port)
+		// this looks wrong, BUT since it's a uni-directional tchannel
+		// connection, we have to pass CallerName as the tchannel "ServiceName"
+		// for source/destination to be reported correctly by RPC layer.
 		ts, err := tchannel.NewChannelTransport(tchannel.ServiceName(cfg.CallerName))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
It's misleading, but when we setup the outbound TChannel, we were using `cfg.ServiceName` when setting up TChannel. Since this is a uni-directional connection, we should instead be using `cfg.CallerName` for source metrics to be reported correctly.