### PR TITLE
[CLI] Set service name dynamically if not provided

### DIFF
--- a/cmd/dosa/main.go
+++ b/cmd/dosa/main.go
@@ -38,7 +38,7 @@ type GlobalOptions struct {
 	Host        string   `long:"host" default:"127.0.0.1" description:"The hostname or IP for the gateway."`
 	Port        string   `short:"p" long:"port" default:"21300" description:"The hostname or IP for the gateway."`
 	Transport   string   `long:"transport" default:"tchannel" description:"TCP Transport to use. Options: http, tchannel."`
-	ServiceName string   `long:"service" default:"dosa-gateway" description:"The TChannel service name for the gateway."`
+	ServiceName string   `long:"service" description:"The TChannel service name for the gateway."`
 	CallerName  string   `long:"caller" default:"dosacli-$USER" description:"Caller will override the default caller name (which is dosacli-$USER)."`
 	Timeout     timeFlag `long:"timeout" default:"60s" description:"The timeout for gateway requests. E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds are assumed."`
 	Connector   string   `hidden:"true" long:"connector" default:"yarpc" description:"Name of connector to use"`

--- a/cmd/dosa/main.go
+++ b/cmd/dosa/main.go
@@ -53,7 +53,7 @@ func main() {
 	OptionsParser.ShortDescription = "DOSA CLI - The command-line tool for your DOSA client"
 	OptionsParser.LongDescription = `
 dosa manages your schema both in production and development scopes`
-	c, _ := OptionsParser.AddCommand("scope", "commands to manage scope", "create, drop, or truncate development scopes", &ScopeCmd{})
+	c, _ := OptionsParser.AddCommand("scope", "commands to manage scope", "create, drop, or truncate development scopes", &ScopeOptions{})
 	_, _ = c.AddCommand("create", "Create scope", "creates a new scope", &ScopeCreate{})
 	_, _ = c.AddCommand("drop", "Drop scope", "drops a scope", &ScopeDrop{})
 	_, _ = c.AddCommand("truncate", "Truncate scope", "truncates a scope", &ScopeTruncate{})

--- a/cmd/dosa/options.go
+++ b/cmd/dosa/options.go
@@ -29,6 +29,12 @@ import (
 	"github.com/uber-go/dosa"
 )
 
+const (
+	_defServiceName  = "dosa-dev-gateway"
+	_prodServiceName = "dosa-gateway"
+	_prodScope       = "production"
+)
+
 type timeFlag time.Duration
 
 func (t *timeFlag) setDuration(d time.Duration) {

--- a/cmd/dosa/schema.go
+++ b/cmd/dosa/schema.go
@@ -35,12 +35,6 @@ import (
 	"github.com/uber-go/dosa/schema/uql"
 )
 
-const (
-	_defServiceName  = "dosa-dev-gateway"
-	_prodServiceName = "dosa-gateway"
-	_prodScope       = "production"
-)
-
 var (
 	schemaDumpOutputTypes = map[string]bool{
 		"cql":  true,

--- a/cmd/dosa/schema.go
+++ b/cmd/dosa/schema.go
@@ -56,6 +56,11 @@ type SchemaCmd struct {
 	NamePrefix string `long:"prefix" description:"Name prefix for schema types." required:"true"`
 }
 
+// SchemaArgs specifies the required positional args for schema commands
+type SchemaArgs struct {
+	Paths []string `positional-arg-name:"paths" default:"."`
+}
+
 func (c *SchemaCmd) doSchemaOp(name string, f func(dosa.AdminClient, context.Context, string) (*dosa.SchemaStatus, error), args []string) error {
 	if c.Verbose {
 		fmt.Printf("executing %s with %v\n", name, args)
@@ -108,6 +113,7 @@ func (c *SchemaCmd) doSchemaOp(name string, f func(dosa.AdminClient, context.Con
 // SchemaCheck holds the options for 'schema check'
 type SchemaCheck struct {
 	*SchemaCmd
+	*SchemaArgs `positional-args:"yes"`
 }
 
 // Execute executes a schema check command
@@ -118,6 +124,7 @@ func (c *SchemaCheck) Execute(args []string) error {
 // SchemaUpsert contains data for executing schema upsert command.
 type SchemaUpsert struct {
 	*SchemaCmd
+	*SchemaArgs `positional-args:"yes"`
 }
 
 // Execute executes a schema upsert command
@@ -128,7 +135,8 @@ func (c *SchemaUpsert) Execute(args []string) error {
 // SchemaDump contains data for executing the schema dump command
 type SchemaDump struct {
 	*SchemaOptions
-	Format string `long:"format" short:"f" description:"output format" choice:"cql" choice:"uql" choice:"avro" default:"cql"`
+	*SchemaArgs `positional-args:"yes"`
+	Format      string `long:"format" short:"f" description:"output format" choice:"cql" choice:"uql" choice:"avro" default:"cql"`
 }
 
 // Execute executes a schema dump command

--- a/cmd/dosa/schema.go
+++ b/cmd/dosa/schema.go
@@ -115,8 +115,6 @@ type SchemaCheck struct {
 
 // Execute executes a schema check command
 func (c *SchemaCheck) Execute(args []string) error {
-	fmt.Println("Paths")
-	fmt.Println(c.Args.Paths)
 	return c.doSchemaOp("schema check", dosa.AdminClient.CheckSchema, c.Args.Paths)
 }
 

--- a/cmd/dosa/schema.go
+++ b/cmd/dosa/schema.go
@@ -56,11 +56,6 @@ type SchemaCmd struct {
 	NamePrefix string `long:"prefix" description:"Name prefix for schema types." required:"true"`
 }
 
-// SchemaArgs specifies the required positional args for schema commands
-type SchemaArgs struct {
-	Paths []string `positional-arg-name:"paths" default:"."`
-}
-
 func (c *SchemaCmd) doSchemaOp(name string, f func(dosa.AdminClient, context.Context, string) (*dosa.SchemaStatus, error), args []string) error {
 	if c.Verbose {
 		fmt.Printf("executing %s with %v\n", name, args)
@@ -113,30 +108,38 @@ func (c *SchemaCmd) doSchemaOp(name string, f func(dosa.AdminClient, context.Con
 // SchemaCheck holds the options for 'schema check'
 type SchemaCheck struct {
 	*SchemaCmd
-	*SchemaArgs `positional-args:"yes"`
+	Args struct {
+		Paths []string `positional-arg-name:"paths"`
+	} `positional-args:"yes"`
 }
 
 // Execute executes a schema check command
 func (c *SchemaCheck) Execute(args []string) error {
-	return c.doSchemaOp("schema check", dosa.AdminClient.CheckSchema, args)
+	fmt.Println("Paths")
+	fmt.Println(c.Args.Paths)
+	return c.doSchemaOp("schema check", dosa.AdminClient.CheckSchema, c.Args.Paths)
 }
 
 // SchemaUpsert contains data for executing schema upsert command.
 type SchemaUpsert struct {
 	*SchemaCmd
-	*SchemaArgs `positional-args:"yes"`
+	Args struct {
+		Paths []string `positional-arg-name:"paths"`
+	} `positional-args:"yes"`
 }
 
 // Execute executes a schema upsert command
 func (c *SchemaUpsert) Execute(args []string) error {
-	return c.doSchemaOp("schema upsert", dosa.AdminClient.UpsertSchema, args)
+	return c.doSchemaOp("schema upsert", dosa.AdminClient.UpsertSchema, c.Args.Paths)
 }
 
 // SchemaDump contains data for executing the schema dump command
 type SchemaDump struct {
 	*SchemaOptions
-	*SchemaArgs `positional-args:"yes"`
-	Format      string `long:"format" short:"f" description:"output format" choice:"cql" choice:"uql" choice:"avro" default:"cql"`
+	Format string `long:"format" short:"f" description:"output format" choice:"cql" choice:"uql" choice:"avro" default:"cql"`
+	Args   struct {
+		Paths []string `positional-arg-name:"paths"`
+	} `positional-args:"yes"`
 }
 
 // Execute executes a schema dump command
@@ -149,8 +152,8 @@ func (c *SchemaDump) Execute(args []string) error {
 
 	// no connection necessary
 	client := dosa.NewAdminClient(&devnull.Connector{})
-	if len(args) != 0 {
-		dirs, err := expandDirectories(args)
+	if len(c.Args.Paths) != 0 {
+		dirs, err := expandDirectories(c.Args.Paths)
 		if err != nil {
 			return errors.Wrap(err, "could not expand directories")
 		}

--- a/cmd/dosa/schema.go
+++ b/cmd/dosa/schema.go
@@ -35,6 +35,12 @@ import (
 	"github.com/uber-go/dosa/schema/uql"
 )
 
+const (
+	_defServiceName  = "dosa-dev-gateway"
+	_prodServiceName = "dosa-gateway"
+	_prodScope       = "production"
+)
+
 var (
 	schemaDumpOutputTypes = map[string]bool{
 		"cql":  true,
@@ -62,6 +68,15 @@ func (c *SchemaCmd) doSchemaOp(name string, f func(dosa.AdminClient, context.Con
 		fmt.Printf("options are %+v\n", *c)
 		fmt.Printf("global options are %+v\n", options)
 	}
+
+	// if not given, set the service name dynamically based on scope
+	if options.ServiceName == "" {
+		options.ServiceName = _defServiceName
+		if c.Scope == _prodScope {
+			options.ServiceName = _prodServiceName
+		}
+	}
+
 	client, err := getAdminClient(options)
 	if err != nil {
 		return err

--- a/cmd/dosa/schema_test.go
+++ b/cmd/dosa/schema_test.go
@@ -92,7 +92,7 @@ func TestSchema_ExpandDirectories(t *testing.T) {
 	os.Chdir("..")
 }
 
-func TestSchema_DefaultScope(t *testing.T) {
+func TestSchema_ServiceInference(t *testing.T) {
 	tcs := []struct {
 		serviceName string
 		scope       string

--- a/cmd/dosa/schema_test.go
+++ b/cmd/dosa/schema_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/dosa"
 	"github.com/uber-go/dosa/mocks"
+
+	_ "github.com/uber-go/dosa/connectors/devnull"
 )
 
 func TestSchema_ExpandDirectories(t *testing.T) {
@@ -90,76 +92,131 @@ func TestSchema_ExpandDirectories(t *testing.T) {
 	os.Chdir("..")
 }
 
-func TestSchema_Check_PrefixRequired(t *testing.T) {
-	c := StartCapture()
-	exit = func(r int) {}
-	os.Args = []string{"dosa", "schema", "check", "../../testentity"}
-	main()
-	assert.Contains(t, c.stop(true), "--prefix' was not specified")
+func TestSchema_DefaultScope(t *testing.T) {
+	tcs := []struct {
+		serviceName string
+		scope       string
+		expected    string
+	}{
+		//  service = "", scope = "" -> default
+		{
+			expected: _defServiceName,
+		},
+		//  service = "", scope != prod -> default
+		{
+			scope:    "not-production",
+			expected: _defServiceName,
+		},
+		//  service = "", scope = prod -> prod
+		{
+			scope:    _prodScope,
+			expected: _prodServiceName,
+		},
+		//  service = "foo", scope = "" -> "foo"
+		{
+			serviceName: "foo",
+			expected:    "foo",
+		},
+		//  service = "bar", scope != prod -> "bar"
+		{
+			serviceName: "bar",
+			scope:       "bar",
+			expected:    "bar",
+		},
+		//  service = "baz", scope = prod -> "baz"
+		{
+			serviceName: "baz",
+			scope:       _prodScope,
+			expected:    "baz",
+		},
+	}
+
+	for _, tc := range tcs {
+		for _, cmd := range []string{"check", "upsert"} {
+			os.Args = []string{
+				"dosa",
+				"--service", tc.serviceName,
+				"--connector", "devnull",
+				"schema",
+				cmd,
+				"--prefix", "foo",
+				"--scope", tc.scope,
+				"../../testentity",
+			}
+			main()
+			assert.Equal(t, options.ServiceName, tc.expected)
+		}
+	}
 }
 
-func TestSchema_Upsert_PrefixRequired(t *testing.T) {
-	c := StartCapture()
-	exit = func(r int) {}
-	os.Args = []string{"dosa", "schema", "upsert", "../../testentity"}
-	main()
-	assert.Contains(t, c.stop(true), "--prefix' was not specified")
+func TestSchema_PrefixRequired(t *testing.T) {
+	for _, cmd := range []string{"check", "upsert"} {
+		c := StartCapture()
+		exit = func(r int) {}
+		os.Args = []string{
+			"dosa",
+			"schema",
+			cmd,
+			"../../testentity",
+		}
+		main()
+		assert.Contains(t, c.stop(true), "--prefix' was not specified")
+	}
 }
 
-func TestSchema_Check_InvalidDirectory(t *testing.T) {
-	c := StartCapture()
-	exit = func(r int) {}
-	os.Args = []string{"dosa", "schema", "check", "--prefix", "foo", "../../testentity", "/dev/null"}
-	main()
-	assert.Contains(t, c.stop(true), "\"/dev/null\" is not a directory")
+func TestSchema_InvalidDirectory(t *testing.T) {
+	// dump is a special snowflake
+	prefixMap := map[string]bool{
+		"check":  true,
+		"upsert": true,
+		"dump":   false,
+	}
+	for cmd, hasPrefix := range prefixMap {
+		c := StartCapture()
+		exit = func(r int) {}
+		os.Args = []string{
+			"dosa",
+			"schema",
+			cmd,
+		}
+		if hasPrefix {
+			os.Args = append(os.Args, "--prefix", "foo")
+		}
+		os.Args = append(os.Args, []string{
+			"-e", "testentity.go",
+			"../../testentity",
+			"/dev/null",
+		}...)
+		main()
+		assert.Contains(t, c.stop(true), "\"/dev/null\" is not a directory")
+	}
 }
 
-func TestSchema_Upsert_InvalidDirectory(t *testing.T) {
-	c := StartCapture()
-	exit = func(r int) {}
-	os.Args = []string{"dosa", "schema", "upsert", "--prefix", "foo", "../../testentity", "/dev/null"}
-	main()
-	assert.Contains(t, c.stop(true), "\"/dev/null\" is not a directory")
-}
-
-func TestSchema_Dump_InvalidDirectory(t *testing.T) {
-	c := StartCapture()
-	exit = func(r int) {}
-	os.Args = []string{"dosa", "schema", "dump", "../../testentity", "/dev/null"}
-	main()
-	assert.Contains(t, c.stop(true), "\"/dev/null\" is not a directory")
-}
-
-func TestSchema_Check_NoEntitiesFound(t *testing.T) {
-	c := StartCapture()
-	exit = func(r int) {}
-	os.Args = []string{"dosa", "schema", "check", "--prefix", "foo", "-e", "testentity.go", "../../testentity"}
-	main()
-	assert.Contains(t, c.stop(true), "no entities found")
-}
-
-func TestSchema_Upsert_NoEntitiesFound(t *testing.T) {
-	c := StartCapture()
-	exit = func(r int) {}
-	os.Args = []string{"dosa", "schema", "upsert", "--prefix", "foo", "-e", "testentity.go", "../../testentity"}
-	main()
-	assert.Contains(t, c.stop(true), "no entities found")
-}
-
-func TestSchema_Dump_NoEntitiesFound(t *testing.T) {
-	c := StartCapture()
-	exit = func(r int) {}
-	os.Args = []string{"dosa", "schema", "dump", "-e", "testentity.go", "../../testentity"}
-	main()
-	assert.Contains(t, c.stop(true), "no entities found")
-}
-
-func TestSchema_Dump_InvalidFormat(t *testing.T) {
-	c := StartCapture()
-	exit = func(r int) {}
-	os.Args = []string{"dosa", "schema", "dump", "-f", "invalid", "../../testentity"}
-	main()
-	assert.Contains(t, c.stop(true), "Invalid value")
+func TestSchema_NoEntitiesFound(t *testing.T) {
+	// dump is a special snowflake
+	prefixMap := map[string]bool{
+		"check":  true,
+		"upsert": true,
+		"dump":   false,
+	}
+	for cmd, hasPrefix := range prefixMap {
+		c := StartCapture()
+		exit = func(r int) {}
+		os.Args = []string{
+			"dosa",
+			"schema",
+			cmd,
+		}
+		if hasPrefix {
+			os.Args = append(os.Args, "--prefix", "foo")
+		}
+		os.Args = append(os.Args, []string{
+			"-e", "testentity.go",
+			"../../testentity",
+		}...)
+		main()
+		assert.Contains(t, c.stop(true), "no entities found")
+	}
 }
 
 // There are 4 tests to perform against each operation
@@ -212,6 +269,14 @@ func TestSchema_Upsert_Happy(t *testing.T) {
 	})
 	os.Args = []string{"dosa", "--connector", "mock", "schema", "upsert", "--prefix", "foo", "-e", "_test.go", "-e", "excludeme.go", "-s", "scope", "-v", "../../testentity"}
 	main()
+}
+
+func TestSchema_Dump_InvalidFormat(t *testing.T) {
+	c := StartCapture()
+	exit = func(r int) {}
+	os.Args = []string{"dosa", "schema", "dump", "-f", "invalid", "../../testentity"}
+	main()
+	assert.Contains(t, c.stop(true), "Invalid value")
 }
 
 func TestSchema_Dump_CQL(t *testing.T) {

--- a/cmd/dosa/scope.go
+++ b/cmd/dosa/scope.go
@@ -28,11 +28,18 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ScopeCmd holds options for scope commands (there aren't any)
-type ScopeCmd struct{}
+// ScopeOptions contains configuration for scope command flags
+type ScopeOptions struct{}
+
+// ScopeArgs specifies the required positional args for scope commands
+type ScopeArgs struct {
+	Scopes []string `positional-arg-name:"scopes" required:"1"`
+}
 
 // ScopeCreate contains data for executing scope create command.
-type ScopeCreate struct{}
+type ScopeCreate struct {
+	*ScopeArgs `positional-args:"yes" required:"1"`
+}
 
 // Execute executes a scope create command
 func (c *ScopeCreate) Execute(args []string) error {
@@ -54,6 +61,7 @@ func (c *ScopeCreate) Execute(args []string) error {
 
 // ScopeDrop contains data for executing scope drop command.
 type ScopeDrop struct {
+	*ScopeArgs `positional-args:"yes" required:"1"`
 }
 
 // Execute executes a scope drop command
@@ -77,6 +85,7 @@ func (c *ScopeDrop) Execute(args []string) error {
 
 // ScopeTruncate contains data for executing scope truncate command.
 type ScopeTruncate struct {
+	*ScopeArgs `positional-args:"yes" required:"1"`
 }
 
 // Execute executes a scope truncate command

--- a/cmd/dosa/scope.go
+++ b/cmd/dosa/scope.go
@@ -23,85 +23,75 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/pkg/errors"
+	"github.com/uber-go/dosa"
 )
 
 // ScopeOptions contains configuration for scope command flags
 type ScopeOptions struct{}
 
-// ScopeArgs specifies the required positional args for scope commands
-type ScopeArgs struct {
-	Scopes []string `positional-arg-name:"scopes" required:"1"`
+// ScopeCmd is a placeholder for all scope commands
+type ScopeCmd struct{}
+
+func (c *ScopeCmd) doScopeOp(name string, f func(dosa.AdminClient, context.Context, string) error, scopes []string) error {
+	// set default service name if one isn't provided, this is done here instead
+	// of in the struct tags because schema and scope commands differ slightly
+	// in how the service name should be inferred.
+	if options.ServiceName == "" {
+		options.ServiceName = _defServiceName // defined in options.go
+	}
+
+	client, err := getAdminClient(options)
+	if err != nil {
+		return err
+	}
+	for _, s := range scopes {
+		ctx, cancel := context.WithTimeout(context.Background(), options.Timeout.Duration())
+		defer cancel()
+		if err := f(client, ctx, s); err != nil {
+			return errors.Wrapf(err, "%s scope on %q", name, s)
+		}
+		fmt.Printf("%s scope %q: OK\n", name, s)
+	}
+	return nil
 }
 
 // ScopeCreate contains data for executing scope create command.
 type ScopeCreate struct {
-	*ScopeArgs `positional-args:"yes" required:"1"`
+	*ScopeCmd
+	Args struct {
+		Scopes []string `positional-arg-name:"scopes" required:"1"`
+	} `positional-args:"yes" required:"1"`
 }
 
 // Execute executes a scope create command
 func (c *ScopeCreate) Execute(args []string) error {
-	client, err := getAdminClient(options)
-	if err != nil {
-		return err
-	}
-
-	for _, s := range args {
-		ctx, cancel := context.WithTimeout(context.Background(), options.Timeout.Duration())
-		defer cancel()
-		if err := client.CreateScope(ctx, s); err != nil {
-			return errors.Wrapf(err, "create scope on %q", s)
-		}
-		fmt.Printf("created scope %q\n", s)
-	}
-	return nil
+	return c.doScopeOp("create", dosa.AdminClient.CreateScope, c.Args.Scopes)
 }
 
 // ScopeDrop contains data for executing scope drop command.
 type ScopeDrop struct {
-	*ScopeArgs `positional-args:"yes" required:"1"`
+	*ScopeCmd
+	Args struct {
+		Scopes []string `positional-arg-name:"scopes" required:"1"`
+	} `positional-args:"yes" required:"1"`
 }
 
 // Execute executes a scope drop command
 func (c *ScopeDrop) Execute(args []string) error {
-	client, err := getAdminClient(options)
-	if err != nil {
-		return err
-	}
-
-	for _, s := range args {
-		ctx, cancel := context.WithTimeout(context.Background(), options.Timeout.Duration())
-		defer cancel()
-		if err := client.DropScope(ctx, s); err != nil {
-			return errors.Wrapf(err, "drop scope on %q", s)
-		}
-		fmt.Printf("dropped scope %q\n", s)
-	}
-
-	return nil
+	return c.doScopeOp("drop", dosa.AdminClient.DropScope, c.Args.Scopes)
 }
 
 // ScopeTruncate contains data for executing scope truncate command.
 type ScopeTruncate struct {
-	*ScopeArgs `positional-args:"yes" required:"1"`
+	*ScopeCmd
+	Args struct {
+		Scopes []string `positional-arg-name:"scopes" required:"1"`
+	} `positional-args:"yes" required:"1"`
 }
 
 // Execute executes a scope truncate command
 func (c *ScopeTruncate) Execute(args []string) error {
-	client, err := getAdminClient(options)
-	if err != nil {
-		return err
-	}
-
-	for _, s := range args {
-		ctx, cancel := context.WithTimeout(context.Background(), options.Timeout.Duration())
-		defer cancel()
-		if err := client.TruncateScope(ctx, s); err != nil {
-			return errors.Wrapf(err, "truncate scope on %q", s)
-		}
-		fmt.Fprintf(os.Stdout, "truncated scope %q\n", s)
-	}
-	return nil
+	return c.doScopeOp("truncate", dosa.AdminClient.TruncateScope, c.Args.Scopes)
 }

--- a/cmd/dosa/scope_test.go
+++ b/cmd/dosa/scope_test.go
@@ -31,13 +31,34 @@ import (
 	"github.com/uber-go/dosa/mocks"
 )
 
-func TestScope_ServiceInference(t *testing.T) {
+func TestScope_ServiceDefault(t *testing.T) {
 	tcs := []struct {
-		scopes   []string
-		expected string
+		serviceName string
+		expected    string
 	}{
-		scopes:   []string{},
-		expected: _defServiceName,
+		//  service = "" -> default
+		{
+			expected: _defServiceName,
+		},
+		//  service = "foo" -> foo
+		{
+			serviceName: "foo",
+			expected:    "foo",
+		},
+	}
+	for _, tc := range tcs {
+		for _, cmd := range []string{"create", "drop", "truncate"} {
+			os.Args = []string{
+				"dosa",
+				"--service", tc.serviceName,
+				"--connector", "devnull",
+				"scope",
+				cmd,
+				"scope",
+			}
+			main()
+			assert.Equal(t, options.ServiceName, tc.expected)
+		}
 	}
 }
 

--- a/cmd/dosa/scope_test.go
+++ b/cmd/dosa/scope_test.go
@@ -31,6 +31,16 @@ import (
 	"github.com/uber-go/dosa/mocks"
 )
 
+func TestScope_ServiceInference(t *testing.T) {
+	tcs := []struct {
+		scopes   []string
+		expected string
+	}{
+		scopes:   []string{},
+		expected: _defServiceName,
+	}
+}
+
 // There are 3 tests to perform on each scope operator:
 // 1 - success case, should call connector once for each provided scope, displaying scope name and operation
 // 2 - failure case, connector's API call generated error, provides name of scope that failed

--- a/connectors/devnull/devnull.go
+++ b/connectors/devnull/devnull.go
@@ -134,3 +134,9 @@ func (c *Connector) ScopeExists(ctx context.Context, scope string) (bool, error)
 func (c *Connector) Shutdown() error {
 	return nil
 }
+
+func init() {
+	dosa.RegisterConnector("devnull", func(args map[string]interface{}) (dosa.Connector, error) {
+		return &Connector{}, nil
+	})
+}


### PR DESCRIPTION
Previously, users had to provide `--service` flag for any non-production scope.

This also adds configuration for positional arguments to be required for `scope` subcommands and to be optional for `schema` subcommands.

Example output:
```
$ dosa scope create
Error: the required argument `scopes (at least 1 argument)` was not provided
```
```
$ dosa scope create -h
Error: Usage:
  dosa [OPTIONS] scope create scopes...
...
```
```
$ dosa schema check -h
Error: Usage:
  dosa [OPTIONS] schema [schema-OPTIONS] check [check-OPTIONS] [paths...]
...
```
