### PR TITLE
Add support for complex type

### DIFF
--- a/connectors/yarpc/helpers.go
+++ b/connectors/yarpc/helpers.go
@@ -54,12 +54,12 @@ func RawValueAsInterface(val dosarpc.RawValue, col dosa.ColumnDefinition) interf
 		if col.CustomType == nil {
 			panic("no custom type defined")
 		}
-		newObject := reflect.Zero(col.CustomType).Elem().Interface().(dosa.CustomObjectInterface)
-		err := newObject.Unmarshal(val.BinaryValue)
+		newObject := reflect.Zero(col.CustomType).Interface().(dosa.CustomObjectInterface)
+		result, err := newObject.Unmarshal(val.BinaryValue)
 		if err != nil {
 			panic(err)
 		}
-		return newObject
+		return result
 	}
 	panic("bad type")
 }

--- a/connectors/yarpc/helpers.go
+++ b/connectors/yarpc/helpers.go
@@ -25,12 +25,13 @@ import (
 
 	"github.com/uber-go/dosa"
 	dosarpc "github.com/uber/dosa-idl/.gen/dosa"
+	"reflect"
 )
 
 // RawValueAsInterface converts a value from the wire to an object implementing the interface
 // based on the dosa type. For example, a TUUID type will get a dosa.UUID object
-func RawValueAsInterface(val dosarpc.RawValue, typ dosa.Type) interface{} {
-	switch typ {
+func RawValueAsInterface(val dosarpc.RawValue, col dosa.ColumnDefinition) interface{} {
+	switch col.Type {
 	case dosa.TUUID:
 		uuid, _ := dosa.BytesToUUID(val.BinaryValue) // TODO: should we handle this error?
 		return uuid
@@ -48,6 +49,17 @@ func RawValueAsInterface(val dosarpc.RawValue, typ dosa.Type) interface{} {
 		return time.Unix(0, *val.Int64Value)
 	case dosa.Bool:
 		return *val.BoolValue
+	case dosa.CustomObject:
+		// create a new customobject based on the type store in column definition
+		if col.CustomType == nil {
+			panic("no custom type defined")
+		}
+		newObject := reflect.Zero(col.CustomType).Elem().Interface().(dosa.CustomObjectInterface)
+		err := newObject.Unmarshal(val.BinaryValue)
+		if err != nil {
+			panic(err)
+		}
+		return newObject
 	}
 	panic("bad type")
 }
@@ -81,6 +93,12 @@ func RawValueFromInterface(i interface{}) *dosarpc.RawValue {
 		return &dosarpc.RawValue{Int64Value: &time}
 	case dosa.UUID:
 		bytes, _ := v.Bytes() // TODO: should we handle this error?
+		return &dosarpc.RawValue{BinaryValue: bytes}
+	case dosa.CustomObjectInterface:
+		bytes, err := v.Marshal()
+		if err != nil {
+			panic(err)
+		}
 		return &dosarpc.RawValue{BinaryValue: bytes}
 	}
 	panic("bad type")
@@ -204,7 +222,7 @@ func decodeResults(ei *dosa.EntityInfo, invals dosarpc.FieldValueMap) map[string
 	for name, value := range invals {
 		for _, col := range ei.Def.Columns {
 			if col.Name == name {
-				result[name] = RawValueAsInterface(*value.ElemValue, col.Type)
+				result[name] = RawValueAsInterface(*value.ElemValue, *col)
 				break
 			}
 		}

--- a/connectors/yarpc/helpers_test.go
+++ b/connectors/yarpc/helpers_test.go
@@ -51,7 +51,9 @@ func TestRawValueFromInterfaceBadType(t *testing.T) {
 
 func TestRawValueAsInterfaceBadType(t *testing.T) {
 	assert.Panics(t, func() {
-		RawValueAsInterface(dosarpc.RawValue{}, dosa.Invalid)
+		RawValueAsInterface(dosarpc.RawValue{}, dosa.ColumnDefinition{
+			Type: dosa.Invalid,
+		})
 	})
 }
 

--- a/connectors/yarpc/yarpc.go
+++ b/connectors/yarpc/yarpc.go
@@ -174,6 +174,7 @@ func (c *Connector) CreateIfNotExists(ctx context.Context, ei *dosa.EntityInfo, 
 
 // Upsert inserts or updates your data
 func (c *Connector) Upsert(ctx context.Context, ei *dosa.EntityInfo, values map[string]dosa.FieldValue) error {
+	// TODO marshal the customized type
 	upsertRequest := dosarpc.UpsertRequest{
 		Ref:          entityInfoToSchemaRef(ei),
 		EntityValues: fieldValueMapFromClientMap(values),
@@ -183,6 +184,7 @@ func (c *Connector) Upsert(ctx context.Context, ei *dosa.EntityInfo, values map[
 
 // Read reads a single entity
 func (c *Connector) Read(ctx context.Context, ei *dosa.EntityInfo, keys map[string]dosa.FieldValue, fieldsToRead []string) (map[string]dosa.FieldValue, error) {
+	// TODO unmarshal the customzied type
 	// Convert the fields from the client's map to a set of fields to read
 	var rpcFieldsToRead map[string]struct{}
 	if fieldsToRead != nil {

--- a/connectors/yarpc/yarpc.go
+++ b/connectors/yarpc/yarpc.go
@@ -257,7 +257,7 @@ func (c *Connector) MultiRead(ctx context.Context, ei *dosa.EntityInfo, keys []m
 		for name, value := range rpcResult.EntityValues {
 			for _, col := range ei.Def.Columns {
 				if col.Name == name {
-					results[i].Values[name] = RawValueAsInterface(*value.ElemValue, col.Type)
+					results[i].Values[name] = RawValueAsInterface(*value.ElemValue, *col)
 					break
 				}
 			}

--- a/connectors/yarpc/yarpc.go
+++ b/connectors/yarpc/yarpc.go
@@ -174,7 +174,6 @@ func (c *Connector) CreateIfNotExists(ctx context.Context, ei *dosa.EntityInfo, 
 
 // Upsert inserts or updates your data
 func (c *Connector) Upsert(ctx context.Context, ei *dosa.EntityInfo, values map[string]dosa.FieldValue) error {
-	// TODO marshal the customized type
 	upsertRequest := dosarpc.UpsertRequest{
 		Ref:          entityInfoToSchemaRef(ei),
 		EntityValues: fieldValueMapFromClientMap(values),
@@ -184,7 +183,6 @@ func (c *Connector) Upsert(ctx context.Context, ei *dosa.EntityInfo, values map[
 
 // Read reads a single entity
 func (c *Connector) Read(ctx context.Context, ei *dosa.EntityInfo, keys map[string]dosa.FieldValue, fieldsToRead []string) (map[string]dosa.FieldValue, error) {
-	// TODO unmarshal the customzied type
 	// Convert the fields from the client's map to a set of fields to read
 	var rpcFieldsToRead map[string]struct{}
 	if fieldsToRead != nil {

--- a/entity.go
+++ b/entity.go
@@ -97,6 +97,7 @@ type ColumnDefinition struct {
 	// TODO: change as need to support tags like pii, searchable, etc
 	// currently it's in the form of a map from tag name to (optional) tag value
 	Tags map[string]string
+	CustomType reflect.Type
 }
 
 // EntityDefinition stores information about a DOSA entity

--- a/entity_parser.go
+++ b/entity_parser.go
@@ -343,7 +343,7 @@ func typify(f reflect.Type) (Type, error) {
 	}
 
 	if f.Implements(objectType) {
-		return CustomizedObject, nil
+		return CustomObject, nil
 	}
 
 	return Invalid, fmt.Errorf("Invalid type %v", f)

--- a/entity_parser.go
+++ b/entity_parser.go
@@ -319,6 +319,7 @@ var (
 	doubleType    = reflect.TypeOf(float64(0.0))
 	stringType    = reflect.TypeOf("")
 	boolType      = reflect.TypeOf(true)
+	objectType    = reflect.TypeOf((*CustomObject)(nil)).Elem()
 )
 
 func typify(f reflect.Type) (Type, error) {
@@ -339,6 +340,10 @@ func typify(f reflect.Type) (Type, error) {
 		return String, nil
 	case boolType:
 		return Bool, nil
+	}
+
+	if f.Implements(objectType) {
+		return CustomizedObject, nil
 	}
 
 	return Invalid, fmt.Errorf("Invalid type %v", f)

--- a/entity_parser.go
+++ b/entity_parser.go
@@ -292,7 +292,14 @@ func parseFieldTag(structField reflect.StructField, dosaAnnotation string) (*Col
 	if err != nil {
 		return nil, err
 	}
-	return parseField(typ, structField.Name, dosaAnnotation)
+	cd, err := parseField(typ, structField.Name, dosaAnnotation)
+	if err != nil {
+		return nil, err
+	}
+	if typ == CustomObject {
+		cd.CustomType = structField.Type
+	}
+	return cd, nil
 }
 
 func parseField(typ Type, name string, tag string) (*ColumnDefinition, error) {
@@ -319,7 +326,7 @@ var (
 	doubleType    = reflect.TypeOf(float64(0.0))
 	stringType    = reflect.TypeOf("")
 	boolType      = reflect.TypeOf(true)
-	objectType    = reflect.TypeOf((*CustomObject)(nil)).Elem()
+	objectType    = reflect.TypeOf((*CustomObjectInterface)(nil)).Elem()
 )
 
 func typify(f reflect.Type) (Type, error) {

--- a/schema/cql/cql.go
+++ b/schema/cql/cql.go
@@ -47,7 +47,7 @@ func typeMap(t dosa.Type) string {
 		return "timestamp"
 	case dosa.TUUID:
 		return "uuid"
-	case dosa.CustomizedObject:
+	case dosa.CustomObject:
 		return "blob"
 	}
 	return "unknown"

--- a/schema/cql/cql.go
+++ b/schema/cql/cql.go
@@ -47,6 +47,8 @@ func typeMap(t dosa.Type) string {
 		return "timestamp"
 	case dosa.TUUID:
 		return "uuid"
+	case dosa.CustomizedObject:
+		return "blob"
 	}
 	return "unknown"
 }

--- a/schema/cql/cql_test.go
+++ b/schema/cql/cql_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/dosa"
+	"encoding/json"
 )
 
 type AllTypes struct {
@@ -55,12 +56,12 @@ type Location struct {
 	Zipcode  string
 }
 
-func (l Location) Marshal(v interface{}) ([]byte, error) {
-	return nil, nil
+func (l Location) Marshal() ([]byte, error) {
+	return json.Marshal(l)
 }
 
-func (l Location) Unmarshal(data []byte, v interface{}) error {
-	return nil
+func (l Location) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, l)
 }
 
 

--- a/schema/cql/cql_test.go
+++ b/schema/cql/cql_test.go
@@ -60,8 +60,14 @@ func (l Location) Marshal() ([]byte, error) {
 	return json.Marshal(l)
 }
 
-func (l Location) Unmarshal(data []byte) error {
-	return json.Unmarshal(data, l)
+func (l Location) Unmarshal(data []byte) (dosa.CustomObjectInterface, error) {
+	newl := &Location{}
+	err := json.Unmarshal(data, newl)
+	if err != nil {
+		return nil, err
+	}
+	return *newl, nil
+
 }
 
 

--- a/schema/cql/cql_test.go
+++ b/schema/cql/cql_test.go
@@ -48,6 +48,28 @@ type SinglePrimaryKey struct {
 	Data        string
 }
 
+
+type Location struct {
+	Name  string
+	Address  string
+	Zipcode  string
+}
+
+func (l Location) Marshal(v interface{}) ([]byte, error) {
+	return nil, nil
+}
+
+func (l Location) Unmarshal(data []byte, v interface{}) error {
+	return nil
+}
+
+
+type CustomizedType struct {
+	dosa.Entity `dosa:"primaryKey=PrimaryKey"`
+	PrimaryKey    dosa.UUID
+	Address Location
+}
+
 func TestCQL(t *testing.T) {
 	data := []struct {
 		Instance  dosa.DomainObject
@@ -60,6 +82,10 @@ func TestCQL(t *testing.T) {
 		{
 			Instance:  &AllTypes{},
 			Statement: `create table "alltypes" ("booltype" boolean, "int32type" int, "int64type" bigint, "doubletype" double, "stringtype" text, "blobtype" blob, "timetype" timestamp, "uuidtype" uuid, primary key (booltype));`,
+		},
+		{
+			Instance: &CustomizedType{},
+			Statement: `create table "customizedtype" ("primarykey" uuid, "address" blob, primary key (primarykey));`,
 		},
 		// TODO: Add more test cases
 	}

--- a/type.go
+++ b/type.go
@@ -58,8 +58,8 @@ const (
 	// Bool is a bool type
 	Bool
 
-	// CustomizedObject is customized struct that implement the customObject interface
-	CustomizedObject
+	// CustomObject is customized struct that implement the customObject interface
+	CustomObject
 )
 
 // UUID stores a string format of uuid.

--- a/type.go
+++ b/type.go
@@ -57,6 +57,9 @@ const (
 
 	// Bool is a bool type
 	Bool
+
+	// CustomizedObject is customized struct that implement the customObject interface
+	CustomizedObject
 )
 
 // UUID stores a string format of uuid.
@@ -109,4 +112,9 @@ func FromString(s string) Type {
 	default:
 		return Invalid
 	}
+}
+
+type CustomObject interface {
+	Marshal(v interface{}) ([]byte, error)
+	Unmarshal(data []byte, v interface{}) error
 }

--- a/type.go
+++ b/type.go
@@ -116,5 +116,5 @@ func FromString(s string) Type {
 
 type CustomObjectInterface interface {
 	Marshal() ([]byte, error)
-	Unmarshal(data []byte) error
+	Unmarshal(data []byte) (CustomObjectInterface, error)
 }

--- a/type.go
+++ b/type.go
@@ -114,7 +114,7 @@ func FromString(s string) Type {
 	}
 }
 
-type CustomObject interface {
-	Marshal(v interface{}) ([]byte, error)
-	Unmarshal(data []byte, v interface{}) error
+type CustomObjectInterface interface {
+	Marshal() ([]byte, error)
+	Unmarshal(data []byte) error
 }


### PR DESCRIPTION
- Purpose:
Provide complex type support. When define schema entities, user can define their custom types. All they need to do is just implement **CustomObjectInterface** interface and provide marshal and unmarshal function. Then this field can be used as a type in entity object.

- Content of this diff:
1. Define a interface for **CustomObjectInterface**.
2. Doing Marshal and Unmarshal for yarpc call.
3. Schema management in cql, convert custom object to byte. 
4. Test