### PR TITLE
Add Matchers for RangeOp and ScanOp

### DIFF
--- a/examples/testing/README.md
+++ b/examples/testing/README.md
@@ -68,3 +68,70 @@ The `client` behavior can then be mocked using `MockClient`:
     }
 
 A complete, runnable example of this can be found in our [testing examples package](https://github.com/uber-go/dosa/tree/master/examples/testing).
+
+## `EqRangeOp` and `EqScanOp`
+
+In addition to the `MockClient`, dosa provides two useful `gomock.Matcher`s. `EqRangeOp` allows you to verify
+that an expected call to `Range` is made with a specific `RangeOp`. `EqScanOp` does the same thing, except for
+the `Scan` function. For instance, assume we have the following entity:
+
+```Go
+type MenuItem struct {
+    dosa.Entity `dosa:"primaryKey=((MenuUUID), MenuItemUUID)"`
+    MenuUUID     dosa.UUID
+    MenuItemUUID dosa.UUID
+    Name         string
+    Description  string
+}
+```
+
+Let's also assume we add the following receiver function to our `DataStore` struct:
+```Go
+func (d *Datastore) GetMenu(ctx context.Context, menuUUID dosa.UUID) ([]*MenuItem, error) {
+	op := dosa.NewRangeOp(&MenuItem{}).Eq("MenuUUID", menuUUID).Limit(50)
+	rangeCtx, rangeCancelFn := context.WithTimeout(ctx, 1*time.Second)
+	defer rangeCancelFn()
+
+	objs, _, err := d.client.Range(rangeCtx, op)
+	if err != nil {
+		return nil, err
+	}
+
+	menuItems := make([]*MenuItem, len(objs))
+	for i, obj := range objs {
+		menuItems[i] = obj.(*MenuItem)
+	}
+	return menuItems, nil
+}
+```
+
+In our tests, we could verify that a particular list of `MenuItem` entities were queried for using the `EqRangeOp`
+like so:
+```Go
+func TestGetMenu(t *testing.T) {
+    ctrl := gomock.NewController(t)
+    defer ctrl.Finish()
+
+    expectedOp := dosa.NewRangeOp(&examples.MenuItem{}).Eq("MenuUUID", menuUUID).Limit(50)
+
+    // mock error from Range call
+    c1 := mocks.NewMockClient(ctrl)
+    c1.EXPECT().Initialize(gomock.Any()).Return(nil).Times(1)
+    c1.EXPECT().Range(gomock.Any(), dosa.EqRangeOp(expectedOp)).Return(nil, "", errors.New("Range Error")).Times(1)
+    ds1, _ := examples.NewDatastore(c1)
+
+    m1, err1 := ds1.GetMenu(ctx, menuUUID)
+    assert.Error(t, err1)
+    assert.Nil(t, m1)
+
+    // happy path
+    c2 := mocks.NewMockClient(ctrl)
+    c2.EXPECT().Initialize(gomock.Any()).Return(nil).Times(1)
+    c2.EXPECT().Range(gomock.Any(), dosa.EqRangeOp(expectedOp)).Return(objMenu, "", nil).Times(1)
+    ds2, _ := examples.NewDatastore(c2)
+
+    m2, err2 := ds2.GetMenu(ctx, menuUUID)
+    assert.NoError(t, err2)
+    assert.Equal(t, menu, m2)
+}
+```

--- a/range.go
+++ b/range.go
@@ -25,8 +25,8 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/pkg/errors"
 	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
 )
 
 // RangeOp is used to specify constraints to Range calls
@@ -145,12 +145,8 @@ func convertRangeOpConditions(r *RangeOp, t *Table) (map[string][]*Condition, er
 	return serverConditions, nil
 }
 
-type CondsMantcher struct {}
-
-
-
 type rangeOpMatcher struct {
-	conds  map[Condition]bool
+	conds    map[Condition]bool
 	eqScanOp gomock.Matcher
 }
 
@@ -165,12 +161,16 @@ func EqRangeOp(op *RangeOp) gomock.Matcher {
 	}
 
 	return rangeOpMatcher{
-		conds: conds,
+		conds:    conds,
 		eqScanOp: EqScanOp(&(op.sop)),
 	}
 }
 func (m rangeOpMatcher) Matches(x interface{}) bool {
-	op := x.(*RangeOp)
+	op, ok := x.(*RangeOp)
+	if !ok {
+		return false
+	}
+
 	for _, conditions := range op.conditions {
 		for _, condition := range conditions {
 			if !m.conds[*condition] {
@@ -184,7 +184,7 @@ func (m rangeOpMatcher) Matches(x interface{}) bool {
 
 func (m rangeOpMatcher) String() string {
 	return fmt.Sprintf(
-		" is equals to RangeOp with conditions %q, and scan op %s",
+		" is equals to RangeOp with conditions %v, and scan op %s",
 		m.conds,
 		m.eqScanOp.String(),
 	)

--- a/range.go
+++ b/range.go
@@ -166,6 +166,8 @@ func EqRangeOp(op *RangeOp) gomock.Matcher {
 		eqScanOp: EqScanOp(&(op.sop)),
 	}
 }
+
+// Matches satisfies the gomock.Matcher interface
 func (m rangeOpMatcher) Matches(x interface{}) bool {
 	op, ok := x.(*RangeOp)
 	if !ok {
@@ -186,6 +188,7 @@ func (m rangeOpMatcher) Matches(x interface{}) bool {
 	return true
 }
 
+// String satisfies the gomock.Matcher and Stringer interface
 func (m rangeOpMatcher) String() string {
 	return fmt.Sprintf(
 		" is equal to RangeOp with conditions %v, and scan op %s",

--- a/range_test.go
+++ b/range_test.go
@@ -126,11 +126,11 @@ func TestConvertRangeOpConditions(t *testing.T) {
 }
 
 func TestRangeOpMatcher(t *testing.T) {
-	RangeOp0 := NewRangeOp(&AllTypes{}).Eq("FieldName", "Hello")
-	RangeOp1 := NewRangeOp(&AllTypes{}).Eq("FieldName", "Hello")
-	RangeOp2 := NewRangeOp(&AllTypes{}).Lt("FieldName", "Hello")
-	RangeOp3 := NewRangeOp(&AllTypes{}).Eq("FieldName", "Hello").Offset("token1")
-	RangeOp4 := NewRangeOp(&AllTypes{}).Eq("FieldName", "Hello").Limit(5)
+	RangeOp0 := NewRangeOp(&AllTypes{}).Eq("StringType", "Hello")
+	RangeOp1 := NewRangeOp(&AllTypes{}).Eq("StringType", "Hello")
+	RangeOp2 := NewRangeOp(&AllTypes{}).Lt("StringType", "Hello")
+	RangeOp3 := NewRangeOp(&AllTypes{}).Eq("StringType", "Hello").Offset("token1")
+	RangeOp4 := NewRangeOp(&AllTypes{}).Eq("StringType", "Hello").Limit(5)
 
 	matcher := EqRangeOp(RangeOp0)
 	assert.True(t, matcher.Matches(RangeOp1))

--- a/range_test.go
+++ b/range_test.go
@@ -124,3 +124,17 @@ func TestConvertRangeOpConditions(t *testing.T) {
 		}
 	}
 }
+
+func TestRangeOpMatcher(t *testing.T) {
+	RangeOp0 := NewRangeOp(&AllTypes{}).Eq("FieldName", "Hello")
+	RangeOp1 := NewRangeOp(&AllTypes{}).Eq("FieldName", "Hello")
+	RangeOp2 := NewRangeOp(&AllTypes{}).Lt("FieldName", "Hello")
+	RangeOp3 := NewRangeOp(&AllTypes{}).Eq("FieldName", "Hello").Offset("token1")
+	RangeOp4 := NewRangeOp(&AllTypes{}).Eq("FieldName", "Hello").Limit(5)
+
+	matcher := EqRangeOp(RangeOp0)
+	assert.True(t, matcher.Matches(RangeOp1))
+	assert.False(t, matcher.Matches(RangeOp2))
+	assert.False(t, matcher.Matches(RangeOp3))
+	assert.False(t, matcher.Matches(RangeOp4))
+}

--- a/range_test.go
+++ b/range_test.go
@@ -137,4 +137,5 @@ func TestRangeOpMatcher(t *testing.T) {
 	assert.False(t, matcher.Matches(RangeOp2))
 	assert.False(t, matcher.Matches(RangeOp3))
 	assert.False(t, matcher.Matches(RangeOp4))
+	assert.False(t, matcher.Matches(3))
 }

--- a/scan.go
+++ b/scan.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+
 	"github.com/golang/mock/gomock"
 )
 
@@ -98,7 +99,11 @@ func EqScanOp(op *ScanOp) gomock.Matcher {
 }
 
 func (m scanOpMatcher) Matches(x interface{}) bool {
-	op := x.(*ScanOp)
+	op, ok := x.(*ScanOp)
+	if !ok {
+		return false
+	}
+
 	for _, field := range op.fieldsToRead {
 		if !m.fields[field] {
 			return false
@@ -110,7 +115,7 @@ func (m scanOpMatcher) Matches(x interface{}) bool {
 
 func (m scanOpMatcher) String() string {
 	return fmt.Sprintf(
-		" is equals to ScanOp with limit %q, token %q, and fields %q",
+		" is equals to ScanOp with limit %q, token %q, and fields %v",
 		m.limit,
 		m.token,
 		m.fields,

--- a/scan.go
+++ b/scan.go
@@ -102,6 +102,7 @@ func EqScanOp(op *ScanOp) gomock.Matcher {
 	}
 }
 
+// Matches satisfies the gomock.Matcher interface
 func (m scanOpMatcher) Matches(x interface{}) bool {
 	op, ok := x.(*ScanOp)
 	if !ok {
@@ -117,6 +118,7 @@ func (m scanOpMatcher) Matches(x interface{}) bool {
 	return op.limit == m.limit && op.token == m.token && reflect.TypeOf(op.object).Elem() == m.typ
 }
 
+// String satisfies the gomock.Matcher and Stringer interface
 func (m scanOpMatcher) String() string {
 	fieldList := make([]string, 0, len(m.fields))
 	for field := range m.fields {

--- a/scan.go
+++ b/scan.go
@@ -26,6 +26,7 @@ import (
 	"io"
 
 	"github.com/golang/mock/gomock"
+	"reflect"
 )
 
 // ScanOp represents the scan query
@@ -81,6 +82,7 @@ type scanOpMatcher struct {
 	limit  int
 	token  string
 	fields map[string]bool
+	typ    reflect.Type
 }
 
 // EqScanOp provides a gomock Matcher that matches any ScanOp with a limit,
@@ -91,10 +93,12 @@ func EqScanOp(op *ScanOp) gomock.Matcher {
 		fields[field] = true
 	}
 
+
 	return scanOpMatcher{
 		limit:  op.limit,
 		token:  op.token,
 		fields: fields,
+		typ:    reflect.TypeOf(op.object).Elem(),
 	}
 }
 
@@ -110,14 +114,15 @@ func (m scanOpMatcher) Matches(x interface{}) bool {
 		}
 	}
 
-	return op.limit == m.limit && op.token == m.token
+	return op.limit == m.limit && op.token == m.token && reflect.TypeOf(op.object).Elem() == m.typ
 }
 
 func (m scanOpMatcher) String() string {
 	return fmt.Sprintf(
-		" is equals to ScanOp with limit %q, token %q, and fields %v",
+		" is equals to ScanOp with limit %q, token %q, dosa entity type %v and fields %v",
 		m.limit,
 		m.token,
+		m.typ,
 		m.fields,
 	)
 }

--- a/scan.go
+++ b/scan.go
@@ -25,8 +25,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/golang/mock/gomock"
 	"reflect"
+
+	"github.com/golang/mock/gomock"
 )
 
 // ScanOp represents the scan query
@@ -93,7 +94,6 @@ func EqScanOp(op *ScanOp) gomock.Matcher {
 		fields[field] = true
 	}
 
-
 	return scanOpMatcher{
 		limit:  op.limit,
 		token:  op.token,
@@ -118,11 +118,15 @@ func (m scanOpMatcher) Matches(x interface{}) bool {
 }
 
 func (m scanOpMatcher) String() string {
+	fieldList := make([]string, 0, len(m.fields))
+	for field := range m.fields {
+		fieldList = append(fieldList, field)
+	}
 	return fmt.Sprintf(
-		" is equals to ScanOp with limit %q, token %q, dosa entity type %v and fields %v",
+		" is equal to ScanOp with limit %d, token %q, dosa entity type %v, and fields %v",
 		m.limit,
 		m.token,
 		m.typ,
-		m.fields,
+		fieldList,
 	)
 }

--- a/scan_test.go
+++ b/scan_test.go
@@ -86,10 +86,12 @@ func TestScanOpMatcher(t *testing.T) {
 	scanOp1 := dosa.NewScanOp(&AllTypes{}).Limit(1)
 	scanOp2 := dosa.NewScanOp(&AllTypes{}).Limit(1).Offset("token1")
 	scanOp3 := dosa.NewScanOp(&AllTypes{}).Limit(1).Fields([]string{"field1", "field2"})
+	scanOp4 := dosa.NewScanOp(&dosa.Entity{}).Limit(1)
 
 	matcher := dosa.EqScanOp(scanOp0)
 	assert.True(t, matcher.Matches(scanOp1))
 	assert.False(t, matcher.Matches(scanOp2))
 	assert.False(t, matcher.Matches(scanOp3))
+	assert.False(t, matcher.Matches(scanOp4))
 	assert.False(t, matcher.Matches(3))
 }

--- a/scan_test.go
+++ b/scan_test.go
@@ -80,3 +80,15 @@ var ScanTestCases = []struct {
 		stringer: "ScanOp",
 	},
 }
+
+func TestScanOpMatcher(t *testing.T) {
+	scanOp0 := dosa.NewScanOp(&AllTypes{}).Limit(1)
+	scanOp1 := dosa.NewScanOp(&AllTypes{}).Limit(1)
+	scanOp2 := dosa.NewScanOp(&AllTypes{}).Limit(1).Offset("token1")
+	scanOp3 := dosa.NewScanOp(&AllTypes{}).Limit(1).Fields([]string{"field1", "field2"})
+
+	matcher := dosa.EqScanOp(scanOp0)
+	assert.True(t, matcher.Matches(scanOp1))
+	assert.False(t, matcher.Matches(scanOp2))
+	assert.False(t, matcher.Matches(scanOp3))
+}

--- a/scan_test.go
+++ b/scan_test.go
@@ -85,7 +85,7 @@ func TestScanOpMatcher(t *testing.T) {
 	scanOp0 := dosa.NewScanOp(&AllTypes{}).Limit(1)
 	scanOp1 := dosa.NewScanOp(&AllTypes{}).Limit(1)
 	scanOp2 := dosa.NewScanOp(&AllTypes{}).Limit(1).Offset("token1")
-	scanOp3 := dosa.NewScanOp(&AllTypes{}).Limit(1).Fields([]string{"field1", "field2"})
+	scanOp3 := dosa.NewScanOp(&AllTypes{}).Limit(1).Fields([]string{"BoolType", "TimeType"})
 	scanOp4 := dosa.NewScanOp(&dosa.Entity{}).Limit(1)
 
 	matcher := dosa.EqScanOp(scanOp0)

--- a/scan_test.go
+++ b/scan_test.go
@@ -91,4 +91,5 @@ func TestScanOpMatcher(t *testing.T) {
 	assert.True(t, matcher.Matches(scanOp1))
 	assert.False(t, matcher.Matches(scanOp2))
 	assert.False(t, matcher.Matches(scanOp3))
+	assert.False(t, matcher.Matches(3))
 }


### PR DESCRIPTION
I was going to write some unit tests for some code that was using DOSA, and I realized I didn't have a good way to tell the mock DOSA client that it should expect a Range call with a certain RangeOp. So I went ahead and made a gomock Matcher for the RangeOp (and the ScanOp as well). The one thing I couldn't really figure out how to do was to compare on the DomainObject of the ScanOp when matching ScanOps. I figure it's not too big of a deal, but if anyone knows how I would love to be enlightened.