### PR TITLE
don't return errors for remove

### DIFF
--- a/connectors/base/base_test.go
+++ b/connectors/base/base_test.go
@@ -99,7 +99,7 @@ func TestBase_Remove(t *testing.T) {
 	assert.Error(t, err)
 
 	err = bcWNext.Remove(ctx, testInfo, testValues)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 func TestBase_MultiRemove(t *testing.T) {

--- a/connectors/devnull/devnull.go
+++ b/connectors/devnull/devnull.go
@@ -69,7 +69,7 @@ func (c *Connector) MultiUpsert(ctx context.Context, ei *dosa.EntityInfo, values
 
 // Remove always returns a not found error
 func (c *Connector) Remove(ctx context.Context, ei *dosa.EntityInfo, values map[string]dosa.FieldValue) error {
-	return &dosa.ErrNotFound{}
+	return nil
 }
 
 // MultiRemove returns a not found error for each value

--- a/connectors/devnull/devnull_test.go
+++ b/connectors/devnull/devnull_test.go
@@ -78,7 +78,7 @@ func TestDevNull_MultiUpsert(t *testing.T) {
 
 func TestDevNull_Remove(t *testing.T) {
 	err := sut.Remove(ctx, testInfo, testValues)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 func TestDevNull_MultiRemove(t *testing.T) {

--- a/connectors/random/random.go
+++ b/connectors/random/random.go
@@ -132,7 +132,7 @@ func (c *Connector) MultiUpsert(ctx context.Context, ei *dosa.EntityInfo, values
 
 // Remove always returns a not found error
 func (c *Connector) Remove(ctx context.Context, ei *dosa.EntityInfo, values map[string]dosa.FieldValue) error {
-	return &dosa.ErrNotFound{}
+	return nil
 }
 
 // MultiRemove returns a not found error for each value

--- a/connectors/random/random_test.go
+++ b/connectors/random/random_test.go
@@ -100,7 +100,7 @@ func TestRandom_MultiUpsert(t *testing.T) {
 
 func TestRandom_Remove(t *testing.T) {
 	err := sut.Remove(ctx, testInfo, testValues)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 func TestRandom_MultiRemove(t *testing.T) {


### PR DESCRIPTION
Standard behavior for the cassandra connector is to not return an error when an attempt is made to remove an entity that doesn't exist. Yet, the devnull and random connectors do just this. I would argue the cassandra connector does the "correct" thing, and we should have the devnull and random connectors follow suit. If you try to delete something and that thing doesn't exist, then it has effectively been deleted. Mission accomplished.

I'm pretty confident about this behavior for devnull, but less so on the random one. Random, in my head, represents an essentially immutable datastore if I'm understanding it correctly. You can only get things from it, not change what's in it. If that's the case, then I would argue the correct behavior is for all modification methods to fail with some different sort of error (including Upsert, MultiUpsert, and CreateIfNotExists). However, that's not the current behavior for those methods. So I think it stands that Remove shouldn't return an error.