### PR TITLE
Add support for entity discovery

### DIFF
--- a/client.go
+++ b/client.go
@@ -561,6 +561,12 @@ type EntityErrors struct {
 	warns []error
 }
 
+// NewEntityErrors returns a wrapper for errors encountered while parsing
+// entity struct tags.
+func NewEntityErrors(warns []error) *EntityErrors {
+	return &EntityErrors{warns: warns}
+}
+
 // Error makes parse errors discernable to end-user.
 func (ee *EntityErrors) Error() string {
 	var str bytes.Buffer

--- a/config/config.go
+++ b/config/config.go
@@ -35,26 +35,26 @@ const (
 	_defExclude    = "_test.go"
 
 	// default timeouts in milliseconds
-	_defInitializeTimeout        = 10000
-	_defCreateIfNotExistsTimeout = 10000
-	_defReadTimeout              = 10000
-	_defUpsertTimeout            = 10000
-	_defRemoveTimeout            = 10000
-	_defRangeTimeout             = 10000
-	_defSearchTimeout            = 10000
-	_defScanEverythingTimeout    = 10000
+	_defCreateIfNotExistsTimeout = time.Duration(10 * time.Second)
+	_defInitializeTimeout        = time.Duration(10 * time.Second)
+	_defRangeTimeout             = time.Duration(10 * time.Second)
+	_defReadTimeout              = time.Duration(2 * time.Second)
+	_defRemoveTimeout            = time.Duration(2 * time.Second)
+	_defScanEverythingTimeout    = time.Duration(10 * time.Second)
+	_defSearchTimeout            = time.Duration(10 * time.Second)
+	_defUpsertTimeout            = time.Duration(2 * time.Second)
 )
 
 // TimeoutConfig holds timeout values for all DOSA operations
 type TimeoutConfig struct {
-	Initialize        time.Duration `yaml:"initialize"`
 	CreateIfNotExists time.Duration `yaml:"createIfNotExists"`
-	Read              time.Duration `yaml:"read"`
-	Upsert            time.Duration `yaml:"upsert"`
-	Remove            time.Duration `yaml:"remove"`
+	Initialize        time.Duration `yaml:"initialize"`
 	Range             time.Duration `yaml:"range"`
-	Search            time.Duration `yaml:"search"`
+	Read              time.Duration `yaml:"read"`
+	Remove            time.Duration `yaml:"remove"`
 	ScanEverything    time.Duration `yaml:"scanEverything"`
+	Search            time.Duration `yaml:"search"`
+	Upsert            time.Duration `yaml:"upsert"`
 }
 
 // Config represents the settings for the dosa client
@@ -90,14 +90,14 @@ func NewDefaultConfig() Config {
 		Excludes:    []string{_defExclude},
 		Connector:   _defaultConn,
 		Timeout: &TimeoutConfig{
-			Initialize:        time.Duration(_defInitializeTimeout) * time.Millisecond,
-			CreateIfNotExists: time.Duration(_defCreateIfNotExistsTimeout) * time.Millisecond,
-			Read:              time.Duration(_defReadTimeout) * time.Millisecond,
-			Upsert:            time.Duration(_defUpsertTimeout) * time.Millisecond,
-			Remove:            time.Duration(_defRemoveTimeout) * time.Millisecond,
-			Range:             time.Duration(_defRangeTimeout) * time.Millisecond,
-			Search:            time.Duration(_defSearchTimeout) * time.Millisecond,
-			ScanEverything:    time.Duration(_defScanEverythingTimeout) * time.Millisecond,
+			CreateIfNotExists: _defCreateIfNotExistsTimeout,
+			Initialize:        _defInitializeTimeout,
+			Range:             _defRangeTimeout,
+			Read:              _defReadTimeout,
+			Remove:            _defRemoveTimeout,
+			ScanEverything:    _defScanEverythingTimeout,
+			Search:            _defSearchTimeout,
+			Upsert:            _defUpsertTimeout,
 		},
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -21,15 +21,51 @@
 package config
 
 import (
+	"time"
+
 	"github.com/uber-go/dosa"
 	"github.com/uber-go/dosa/connectors/yarpc"
 )
 
+const (
+	_defaultConn = "yarpc"
+
+	// default search location and what to exclude
+	_defEntityPath = "./entities/dosa"
+	_defExclude    = "_test.go"
+
+	// default timeouts in milliseconds
+	_defInitializeTimeout        = 10000
+	_defCreateIfNotExistsTimeout = 10000
+	_defReadTimeout              = 10000
+	_defUpsertTimeout            = 10000
+	_defRemoveTimeout            = 10000
+	_defRangeTimeout             = 10000
+	_defSearchTimeout            = 10000
+	_defScanEverythingTimeout    = 10000
+)
+
+// TimeoutConfig holds timeout values for all DOSA operations
+type TimeoutConfig struct {
+	Initialize        time.Duration `yaml:"initialize"`
+	CreateIfNotExists time.Duration `yaml:"createIfNotExists"`
+	Read              time.Duration `yaml:"read"`
+	Upsert            time.Duration `yaml:"upsert"`
+	Remove            time.Duration `yaml:"remove"`
+	Range             time.Duration `yaml:"range"`
+	Search            time.Duration `yaml:"search"`
+	ScanEverything    time.Duration `yaml:"scanEverything"`
+}
+
 // Config represents the settings for the dosa client
 type Config struct {
-	Scope      string       `yaml:"scope"`
-	NamePrefix string       `yaml:"namePrefix"`
-	Yarpc      yarpc.Config `yaml:"yarpc"`
+	Scope       string         `yaml:"scope"`
+	NamePrefix  string         `yaml:"namePrefix"`
+	Connector   string         `yaml:"connector"`
+	EntityPaths []string       `yaml:"entityPaths"`
+	Excludes    []string       `yaml:"excludes"`
+	Yarpc       yarpc.Config   `yaml:"yarpc"`
+	Timeout     *TimeoutConfig `yaml:"timeout"`
 }
 
 // NewClient creates a DOSA client based on the configuration
@@ -45,4 +81,23 @@ func (c Config) NewClient(entities ...dosa.DomainObject) (dosa.Client, error) {
 	}
 
 	return dosa.NewClient(reg, conn), nil
+}
+
+// NewDefaultConfig returns a configuration instance with all default values
+func NewDefaultConfig() Config {
+	return Config{
+		EntityPaths: []string{_defEntityPath},
+		Excludes:    []string{_defExclude},
+		Connector:   _defaultConn,
+		Timeout: &TimeoutConfig{
+			Initialize:        time.Duration(_defInitializeTimeout) * time.Millisecond,
+			CreateIfNotExists: time.Duration(_defCreateIfNotExistsTimeout) * time.Millisecond,
+			Read:              time.Duration(_defReadTimeout) * time.Millisecond,
+			Upsert:            time.Duration(_defUpsertTimeout) * time.Millisecond,
+			Remove:            time.Duration(_defRemoveTimeout) * time.Millisecond,
+			Range:             time.Duration(_defRangeTimeout) * time.Millisecond,
+			Search:            time.Duration(_defSearchTimeout) * time.Millisecond,
+			ScanEverything:    time.Duration(_defScanEverythingTimeout) * time.Millisecond,
+		},
+	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -29,6 +29,13 @@ import (
 	"github.com/uber-go/dosa/connectors/yarpc"
 )
 
+const (
+	testScope      = "testscope"
+	testPrefix     = "testprefix"
+	testEntityPath = "../testentity"
+)
+
+// SinglePartitionKey is used to test NewClient
 type SinglePartitionKey struct {
 	dosa.Entity `dosa:"primaryKey=PrimaryKey"`
 	PrimaryKey  int64

--- a/registry.go
+++ b/registry.go
@@ -205,6 +205,7 @@ type prefixedRegistrar struct {
 // entities provided. `dosa.Client` implementations are intended to use scope
 // and prefix to uniquely identify where entities should live but the
 // registrar itself is only responsible for basic accounting of entities.
+// DEPRECATED: use (github.com/uber-go/dosa/registry).NewRegistrar instead.
 func NewRegistrar(scope, prefix string, entities ...DomainObject) (Registrar, error) {
 	baseFQN, err := ToFQN(prefix)
 	if err != nil {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package registry
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/pkg/errors"
+	"github.com/uber-go/dosa"
+	"github.com/uber-go/dosa/config"
+)
+
+type registrar struct {
+	scope   string
+	prefix  string
+	baseFQN dosa.FQN
+	idx     map[dosa.FQN]*dosa.RegisteredEntity
+}
+
+// Scope returns the registrar's scope.
+func (r *registrar) Scope() string {
+	return r.scope
+}
+
+// NamePrefix returns the registrar's prefix.
+func (r *registrar) NamePrefix() string {
+	return r.prefix
+}
+
+// Find looks at its internal index to find a registration that matches the
+// entity instance provided. Return an error when not found.
+func (r *registrar) Find(entity dosa.DomainObject) (*dosa.RegisteredEntity, error) {
+	name := reflect.TypeOf(entity).Name()
+	fqn, _ := r.baseFQN.Child(name)
+	re, ok := r.idx[fqn]
+	if !ok {
+		return nil, errors.Errorf("failed to find registration for entity %s", name)
+	}
+	return re, nil
+}
+
+// FindAll returns all registered entities from its internal index.
+func (r *registrar) FindAll() ([]*dosa.RegisteredEntity, error) {
+	res := []*dosa.RegisteredEntity{}
+	for _, re := range r.idx {
+		res = append(res, re)
+	}
+	if len(res) == 0 {
+		return nil, fmt.Errorf("registry.FindAll returned empty")
+	}
+	return res, nil
+}
+
+// NewRegistrar returns a new Registrar for the configuration provided.
+func NewRegistrar(cfg *config.Config) (dosa.Registrar, error) {
+	idx := make(map[dosa.FQN]*dosa.RegisteredEntity)
+	baseFQN, err := dosa.ToFQN(cfg.NamePrefix)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to construct Registrar")
+	}
+
+	// "warnings" mean entity was found but contained invalid annotations
+	eds, warns, err := dosa.FindEntities(cfg.EntityPaths, cfg.Excludes)
+	if len(warns) > 0 {
+		return nil, dosa.NewEntityErrors(warns)
+	}
+	// I/O and AST parsing errors
+	if err != nil {
+		return nil, err
+	}
+
+	// index entity definitions (aka "tables")
+	for _, ed := range eds {
+		re := dosa.NewRegisteredEntity(cfg.Scope, cfg.NamePrefix, ed)
+
+		// index by prefix + normalized name (aka "FQN")
+		fqn, _ := baseFQN.Child(ed.StructName)
+		idx[fqn] = re
+	}
+
+	return &registrar{
+		scope:   cfg.Scope,
+		prefix:  cfg.NamePrefix,
+		baseFQN: baseFQN,
+		idx:     idx,
+	}, nil
+}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package registry_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/uber-go/dosa"
+	"github.com/uber-go/dosa/config"
+	"github.com/uber-go/dosa/registry"
+)
+
+type TestEntity struct {
+	dosa.Entity `dosa:"primaryKey=(ID, Name)"`
+	ID          int64
+	Name        string
+	Email       string
+}
+
+func TestRegistrar_Scope(t *testing.T) {
+	assert.Equal(t, true, true)
+}
+
+func TestRegistrar_NamePrefix(t *testing.T) {
+	assert.Equal(t, true, true)
+}
+
+func TestRegistrar_Find(t *testing.T) {
+	assert.Equal(t, true, true)
+}
+
+func TestRegistrar_FindAll(t *testing.T) {
+	assert.Equal(t, true, true)
+}
+
+func TestNewRegistrar(t *testing.T) {
+	cfg := &config.Config{}
+	reg, err := registry.NewRegistrar(cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, reg)
+}

--- a/registry_test.go
+++ b/registry_test.go
@@ -22,12 +22,11 @@ package dosa_test
 
 import (
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"sort"
 
 	"github.com/uber-go/dosa"
 )
@@ -170,6 +169,26 @@ func TestRegisteredEntity_SetFieldValues(t *testing.T) {
 	assert.Equal(t, entity.Email, validFieldValues["email"])
 }
 
+func TestRegisteredEntity_OnlyFieldValues(t *testing.T) {
+	table, _ := dosa.TableFromInstance(&RegistryTestValid{})
+	scope := "test"
+	namePrefix := "team.service"
+
+	re := dosa.NewRegisteredEntity(scope, namePrefix, table)
+	testv := RegistryTestValid{ID: 1, Name: "name", Email: "email"}
+	expected := map[string]dosa.FieldValue{
+		"id":    dosa.FieldValue(int64(1)),
+		"name":  dosa.FieldValue("name"),
+		"email": dosa.FieldValue("email")}
+
+	vals, err := re.OnlyFieldValues(&testv, nil)
+	assert.Equal(t, expected, vals)
+	assert.NoError(t, err)
+	vals, err = re.OnlyFieldValues(&testv, []string{})
+	assert.Equal(t, expected, vals)
+	assert.NoError(t, err)
+}
+
 func TestNewRegistrar(t *testing.T) {
 	entities := []dosa.DomainObject{&RegistryTestValid{}}
 
@@ -211,23 +230,4 @@ func TestRegistrar(t *testing.T) {
 	registered, err = r.FindAll()
 	assert.NoError(t, err)
 	assert.Equal(t, len(registered), len(validEntities))
-}
-func TestRegisteredEntity_OnlyFieldValues(t *testing.T) {
-	table, _ := dosa.TableFromInstance(&RegistryTestValid{})
-	scope := "test"
-	namePrefix := "team.service"
-
-	re := dosa.NewRegisteredEntity(scope, namePrefix, table)
-	testv := RegistryTestValid{ID: 1, Name: "name", Email: "email"}
-	expected := map[string]dosa.FieldValue{
-		"id":    dosa.FieldValue(int64(1)),
-		"name":  dosa.FieldValue("name"),
-		"email": dosa.FieldValue("email")}
-
-	vals, err := re.OnlyFieldValues(&testv, nil)
-	assert.Equal(t, expected, vals)
-	assert.NoError(t, err)
-	vals, err = re.OnlyFieldValues(&testv, []string{})
-	assert.Equal(t, expected, vals)
-	assert.NoError(t, err)
 }


### PR DESCRIPTION
This adds a new `registry` package which implements support for "auto-discovery" of DOSA entities. It was broken out of #151. This will be used in subsequent changes to add support for UberFx.