### PR TITLE
add RemoveRange to yarpc connector

### DIFF
--- a/connectors/yarpc/yarpc.go
+++ b/connectors/yarpc/yarpc.go
@@ -325,7 +325,7 @@ func (c *Connector) Remove(ctx context.Context, ei *dosa.EntityInfo, keys map[st
 func (c *Connector) RemoveRange(ctx context.Context, ei *dosa.EntityInfo, columnConditions map[string][]*dosa.Condition) error {
 	conditions, err := createRpcConditions(columnConditions)
 	if err != nil {
-		errors.Wrap(err, "RemoveRange failed")
+		return errors.Wrap(err, "RemoveRange failed")
 	}
 
 	request := &dosarpc.RemoveRangeRequest{
@@ -350,7 +350,7 @@ func (c *Connector) Range(ctx context.Context, ei *dosa.EntityInfo, columnCondit
 	rpcMinimumFields := makeRPCminimumFields(minimumFields)
 	conditions, err := createRpcConditions(columnConditions)
 	if err != nil {
-		errors.Wrap(err, "Range failed")
+		return nil, "", errors.Wrap(err, "Range failed")
 	}
 	rangeRequest := dosarpc.RangeRequest{
 		Ref:          entityInfoToSchemaRef(ei),

--- a/connectors/yarpc/yarpc.go
+++ b/connectors/yarpc/yarpc.go
@@ -329,7 +329,7 @@ func (c *Connector) RemoveRange(ctx context.Context, ei *dosa.EntityInfo, column
 	}
 
 	request := &dosarpc.RemoveRangeRequest{
-		Ref: entityInfoToSchemaRef(ei),
+		Ref:        entityInfoToSchemaRef(ei),
 		Conditions: conditions,
 	}
 

--- a/connectors/yarpc/yarpc.go
+++ b/connectors/yarpc/yarpc.go
@@ -319,7 +319,24 @@ func (c *Connector) Remove(ctx context.Context, ei *dosa.EntityInfo, keys map[st
 		return errors.Wrap(err, "YARPC Remove failed")
 	}
 	return nil
+}
 
+// RemoveRange removes all entities within the range specified by the columnConditions.
+func (c *Connector) RemoveRange(ctx context.Context, ei *dosa.EntityInfo, columnConditions map[string][]*dosa.Condition) error {
+	conditions, err := createRpcConditions(columnConditions)
+	if err != nil {
+		errors.Wrap(err, "RemoveRange failed")
+	}
+
+	request := &dosarpc.RemoveRangeRequest{
+		Ref: entityInfoToSchemaRef(ei),
+		Conditions: conditions,
+	}
+
+	if err := c.Client.RemoveRange(ctx, request); err != nil {
+		return errors.Wrap(err, "YARPC RemoveRange failed")
+	}
+	return nil
 }
 
 // MultiRemove is not yet implemented
@@ -331,27 +348,15 @@ func (c *Connector) MultiRemove(ctx context.Context, ei *dosa.EntityInfo, multiK
 func (c *Connector) Range(ctx context.Context, ei *dosa.EntityInfo, columnConditions map[string][]*dosa.Condition, minimumFields []string, token string, limit int) ([]map[string]dosa.FieldValue, string, error) {
 	limit32 := int32(limit)
 	rpcMinimumFields := makeRPCminimumFields(minimumFields)
-	rpcConditions := []*dosarpc.Condition{}
-	for field, conditions := range columnConditions {
-		// Warning: Don't remove this line.
-		// field variable always has the same address. If we want to dereference it, we have to assign the value to a new variable.
-		fieldName := field
-		for _, condition := range conditions {
-			rv, err := RawValueFromInterface(condition.Value)
-			if err != nil {
-				return nil, "", errors.Wrap(err, "Bad range value")
-			}
-			rpcConditions = append(rpcConditions, &dosarpc.Condition{
-				Op:    encodeOperator(condition.Op),
-				Field: &dosarpc.Field{Name: &fieldName, Value: &dosarpc.Value{ElemValue: rv}},
-			})
-		}
+	conditions, err := createRpcConditions(columnConditions)
+	if err != nil {
+		errors.Wrap(err, "Range failed")
 	}
 	rangeRequest := dosarpc.RangeRequest{
 		Ref:          entityInfoToSchemaRef(ei),
 		Token:        &token,
 		Limit:        &limit32,
-		Conditions:   rpcConditions,
+		Conditions:   conditions,
 		FieldsToRead: rpcMinimumFields,
 	}
 	response, err := c.Client.Range(ctx, &rangeRequest)
@@ -363,6 +368,27 @@ func (c *Connector) Range(ctx context.Context, ei *dosa.EntityInfo, columnCondit
 		results = append(results, decodeResults(ei, entity))
 	}
 	return results, *response.NextToken, nil
+}
+
+func createRpcConditions(columnConditions map[string][]*dosa.Condition) ([]*dosarpc.Condition, error) {
+	rpcConditions := []*dosarpc.Condition{}
+	for field, conditions := range columnConditions {
+		// Warning: Don't remove this line.
+		// field variable always has the same address. If we want to dereference it, we have to assign the value to a new variable.
+		fieldName := field
+		for _, condition := range conditions {
+			rv, err := RawValueFromInterface(condition.Value)
+			if err != nil {
+				return nil, errors.Wrap(err, "Bad range value")
+			}
+			rpcConditions = append(rpcConditions, &dosarpc.Condition{
+				Op:    encodeOperator(condition.Op),
+				Field: &dosarpc.Field{Name: &fieldName, Value: &dosarpc.Value{ElemValue: rv}},
+			})
+		}
+	}
+
+	return rpcConditions, nil
 }
 
 // Search is not yet implemented

--- a/connectors/yarpc/yarpc.go
+++ b/connectors/yarpc/yarpc.go
@@ -323,7 +323,7 @@ func (c *Connector) Remove(ctx context.Context, ei *dosa.EntityInfo, keys map[st
 
 // RemoveRange removes all entities within the range specified by the columnConditions.
 func (c *Connector) RemoveRange(ctx context.Context, ei *dosa.EntityInfo, columnConditions map[string][]*dosa.Condition) error {
-	conditions, err := createRpcConditions(columnConditions)
+	conditions, err := createRPCConditions(columnConditions)
 	if err != nil {
 		return errors.Wrap(err, "RemoveRange failed")
 	}
@@ -348,7 +348,7 @@ func (c *Connector) MultiRemove(ctx context.Context, ei *dosa.EntityInfo, multiK
 func (c *Connector) Range(ctx context.Context, ei *dosa.EntityInfo, columnConditions map[string][]*dosa.Condition, minimumFields []string, token string, limit int) ([]map[string]dosa.FieldValue, string, error) {
 	limit32 := int32(limit)
 	rpcMinimumFields := makeRPCminimumFields(minimumFields)
-	conditions, err := createRpcConditions(columnConditions)
+	conditions, err := createRPCConditions(columnConditions)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "Range failed")
 	}
@@ -370,7 +370,7 @@ func (c *Connector) Range(ctx context.Context, ei *dosa.EntityInfo, columnCondit
 	return results, *response.NextToken, nil
 }
 
-func createRpcConditions(columnConditions map[string][]*dosa.Condition) ([]*dosarpc.Condition, error) {
+func createRPCConditions(columnConditions map[string][]*dosa.Condition) ([]*dosarpc.Condition, error) {
 	rpcConditions := []*dosarpc.Condition{}
 	for field, conditions := range columnConditions {
 		// Warning: Don't remove this line.

--- a/connectors/yarpc/yarpc.go
+++ b/connectors/yarpc/yarpc.go
@@ -323,14 +323,14 @@ func (c *Connector) Remove(ctx context.Context, ei *dosa.EntityInfo, keys map[st
 
 // RemoveRange removes all entities within the range specified by the columnConditions.
 func (c *Connector) RemoveRange(ctx context.Context, ei *dosa.EntityInfo, columnConditions map[string][]*dosa.Condition) error {
-	conditions, err := createRPCConditions(columnConditions)
+	rpcConditions, err := createRPCConditions(columnConditions)
 	if err != nil {
 		return errors.Wrap(err, "RemoveRange failed")
 	}
 
 	request := &dosarpc.RemoveRangeRequest{
 		Ref:        entityInfoToSchemaRef(ei),
-		Conditions: conditions,
+		Conditions: rpcConditions,
 	}
 
 	if err := c.Client.RemoveRange(ctx, request); err != nil {
@@ -348,7 +348,7 @@ func (c *Connector) MultiRemove(ctx context.Context, ei *dosa.EntityInfo, multiK
 func (c *Connector) Range(ctx context.Context, ei *dosa.EntityInfo, columnConditions map[string][]*dosa.Condition, minimumFields []string, token string, limit int) ([]map[string]dosa.FieldValue, string, error) {
 	limit32 := int32(limit)
 	rpcMinimumFields := makeRPCminimumFields(minimumFields)
-	conditions, err := createRPCConditions(columnConditions)
+	rpcConditions, err := createRPCConditions(columnConditions)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "Range failed")
 	}
@@ -356,7 +356,7 @@ func (c *Connector) Range(ctx context.Context, ei *dosa.EntityInfo, columnCondit
 		Ref:          entityInfoToSchemaRef(ei),
 		Token:        &token,
 		Limit:        &limit32,
-		Conditions:   conditions,
+		Conditions:   rpcConditions,
 		FieldsToRead: rpcMinimumFields,
 	}
 	response, err := c.Client.Range(ctx, &rangeRequest)

--- a/connectors/yarpc/yarpc_test.go
+++ b/connectors/yarpc/yarpc_test.go
@@ -743,7 +743,7 @@ func TestConnector_RemoveRange(t *testing.T) {
 	// perform a generic error request
 	mockedClient.EXPECT().RemoveRange(ctx, gomock.Any()).Return(errors.New("test error")).Times(1)
 	err = sut.RemoveRange(ctx, testEi, map[string][]*dosa.Condition{"c2": {&dosa.Condition{
-		Value: float64(3.3),
+		Value: 3.3,
 		Op:    dosa.Eq,
 	}}})
 	assert.Error(t, err)

--- a/connectors/yarpc/yarpc_test.go
+++ b/connectors/yarpc/yarpc_test.go
@@ -703,6 +703,43 @@ func TestConnector_Range(t *testing.T) {
 	assert.Contains(t, err.Error(), "test error")
 }
 
+func TestConnector_RemoveRange(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockedClient := dosatest.NewMockClient(ctrl)
+
+	sut := yarpc.Connector{Client: mockedClient}
+	fieldName := "c1"
+	field := drpc.Field{&fieldName, &drpc.Value{ElemValue: &drpc.RawValue{Int64Value: testInt64Ptr(10)}}}
+	op := drpc.OperatorEq
+
+	mockedClient.EXPECT().RemoveRange(ctx, gomock.Any()).Do(func(_ context.Context, request *drpc.RemoveRangeRequest){
+		assert.Equal(t, testRPCSchemaRef, *request.Ref)
+		assert.Equal(t, len(request.Conditions), 1)
+		condition := request.Conditions[0]
+		assert.Equal(t, fieldName, *condition.Field.Name)
+		assert.Equal(t, field.Value, condition.Field.Value)
+		assert.Equal(t, &op, condition.Op)
+	}).Return(nil)
+
+	err := sut.RemoveRange(ctx, testEi, map[string][]*dosa.Condition{
+		"c1": {&dosa.Condition{
+			Value: int64(10),
+			Op:    dosa.Eq,
+		}},
+	})
+	assert.NoError(t, err)
+
+	// perform a generic error request
+	mockedClient.EXPECT().RemoveRange(ctx, gomock.Any()).Return(errors.New("test error")).Times(1)
+	err = sut.RemoveRange(ctx, testEi, map[string][]*dosa.Condition{"c2": {&dosa.Condition{
+		Value: float64(3.3),
+		Op:    dosa.Eq,
+	}}})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "test error")
+}
+
 func TestConnector_Scan(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/connectors/yarpc/yarpc_test.go
+++ b/connectors/yarpc/yarpc_test.go
@@ -723,7 +723,7 @@ func TestConnector_RemoveRange(t *testing.T) {
 	field := drpc.Field{&fieldName, &drpc.Value{ElemValue: &drpc.RawValue{Int64Value: testInt64Ptr(10)}}}
 	op := drpc.OperatorEq
 
-	mockedClient.EXPECT().RemoveRange(ctx, gomock.Any()).Do(func(_ context.Context, request *drpc.RemoveRangeRequest){
+	mockedClient.EXPECT().RemoveRange(ctx, gomock.Any()).Do(func(_ context.Context, request *drpc.RemoveRangeRequest) {
 		assert.Equal(t, testRPCSchemaRef, *request.Ref)
 		assert.Equal(t, len(request.Conditions), 1)
 		condition := request.Conditions[0]

--- a/connectors/yarpc/yarpc_test.go
+++ b/connectors/yarpc/yarpc_test.go
@@ -701,6 +701,16 @@ func TestConnector_Range(t *testing.T) {
 	assert.Empty(t, token)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "test error")
+
+	// perform remove range with a bad field value
+	_, _, err = sut.Range(ctx, testEi, map[string][]*dosa.Condition{
+		"c7": {&dosa.Condition{
+			Value: dosa.UUID("baduuid"),
+			Op:    dosa.Eq,
+		}},
+	}, nil, "", 64)
+	assert.Error(t, err)
+	assert.EqualError(t, errors.Cause(err), "uuid: UUID string too short: baduuid")
 }
 
 func TestConnector_RemoveRange(t *testing.T) {
@@ -738,6 +748,16 @@ func TestConnector_RemoveRange(t *testing.T) {
 	}}})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "test error")
+
+	// perform remove range with a bad field value
+	err = sut.RemoveRange(ctx, testEi, map[string][]*dosa.Condition{
+		"c7": {&dosa.Condition{
+			Value: dosa.UUID("baduuid"),
+			Op:    dosa.Eq,
+		}},
+	})
+	assert.Error(t, err)
+	assert.EqualError(t, errors.Cause(err), "uuid: UUID string too short: baduuid")
 }
 
 func TestConnector_Scan(t *testing.T) {


### PR DESCRIPTION
This is part of a broader effort to enable the removal of a range of values.  The Yarpc connector is the last connector that does not have a RemoveRange reciever function on it. Once the yarpc connector has this function, we can actually alter the Connector interface to include a RemoveRange function and then add the functionality to the client.