### PR TITLE
[Hard] Update glide dependencies

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,14 +1,28 @@
 hash: 7d1e85d070980bf11cab0f4dc869c2af64ecfaf41b1ccb52eaa5db06184b23ba
-updated: 2017-05-03T14:11:01.313181441-07:00
+updated: 2017-06-03T12:52:57.781383255-07:00
 imports:
+- name: github.com/beorn7/perks
+  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  subpackages:
+  - quantile
 - name: github.com/elodina/go-avro
   version: 0c8185d9a3ba82aeac98db3313a268a5b6df99b5
+- name: github.com/facebookgo/clock
+  version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
 - name: github.com/golang/mock
   version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
   subpackages:
   - gomock
+- name: github.com/golang/protobuf
+  version: 5a0f697c9ed9d68fef0116532c6e05cfeae00e55
+  subpackages:
+  - proto
 - name: github.com/jessevdk/go-flags
-  version: 460c7bb0abd6e927f2767cadc91aa6ef776a98b4
+  version: 5695738f733662da3e9afc2283bba6f3c879002d
+- name: github.com/matttproud/golang_protobuf_extensions
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  subpackages:
+  - pbutil
 - name: github.com/opentracing/opentracing-go
   version: 1949ddbfd147afd4d964a9f00b24eb291e0e7c38
   subpackages:
@@ -16,6 +30,25 @@ imports:
   - log
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
+- name: github.com/prometheus/client_golang
+  version: c5b7fccd204277076155f10851dad72b76a49317
+  subpackages:
+  - prometheus
+  - prometheus/promhttp
+- name: github.com/prometheus/client_model
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
+  subpackages:
+  - go
+- name: github.com/prometheus/common
+  version: 13ba4ddd0caa9c28ca7b7bffe1dfa9ed8d5ef207
+  subpackages:
+  - expfmt
+  - internal/bitbucket.org/ww/goautoneg
+  - model
+- name: github.com/prometheus/procfs
+  version: 65c1f6f8f0fc1e2185eb9863a3bc751496404259
+  subpackages:
+  - xfs
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/stretchr/testify
@@ -24,20 +57,23 @@ imports:
   - assert
   - mock
 - name: github.com/uber-go/atomic
-  version: 3b8db5e93c4c02efbc313e17b2e796b0914a01fb
+  version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
+- name: github.com/uber-go/tally
+  version: e9b601813b0be4771b1b3995390567b67ab2b3fc
 - name: github.com/uber/dosa-idl
-  version: 74e0688e5ca1e009de399d0f35884ef7163f4b85
+  version: c2232eaffb054442105c493c79a37ff08389e34b
   subpackages:
   - .gen
   - .gen/dosa
   - .gen/dosa/dosaclient
   - .gen/dosa/dosatest
 - name: github.com/uber/tchannel-go
-  version: 0b7f160817553b0bacb5b108dd84a5022dbdd1c4
+  version: b99c1d7cecb0fdc882bed0098e7cae6ec7459059
   subpackages:
   - internal/argreader
   - relay
   - tnet
+  - tos
   - trand
   - typed
 - name: github.com/yarpc/yarpc-go
@@ -46,6 +82,8 @@ imports:
   version: c416d99ab5ed256fa30c1f3bab73152deb59bb69
 - name: go.uber.org/atomic
   version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
+- name: go.uber.org/multierr
+  version: a3d1fc1f1316d4132fc61f4ea1159ae0613fb474
 - name: go.uber.org/thriftrw
   version: dde90c2a40f45fb2b6361d13c1b4bf09465401c0
   subpackages:
@@ -58,7 +96,7 @@ imports:
   - version
   - wire
 - name: go.uber.org/yarpc
-  version: 6ae533f0810337028ef055b690360e050aa13219
+  version: 6b9245d126758870690c44f27f695cc7e811f913
   subpackages:
   - api/encoding
   - api/middleware
@@ -75,7 +113,10 @@ imports:
   - internal/introspection
   - internal/iopool
   - internal/net
+  - internal/observability
   - internal/outboundmiddleware
+  - internal/pally
+  - internal/procedure
   - internal/request
   - internal/sync
   - peer
@@ -83,11 +124,25 @@ imports:
   - transport/http
   - transport/tchannel
   - transport/tchannel/internal
-- name: golang.org/x/net
-  version: ffcf1bedda3b04ebb15a168a59800a73d6dc0f4d
+- name: go.uber.org/zap
+  version: fab453050a7a08c35f31fc5fff6f2dbd962285ab
   subpackages:
+  - buffer
+  - internal/bufferpool
+  - internal/color
+  - internal/exit
+  - internal/multierror
+  - zapcore
+- name: golang.org/x/net
+  version: e4fa1c5465ad6111f206fc92186b8c83d64adbe1
+  repo: https://github.com/golang/net
+  subpackages:
+  - bpf
   - context
-  - context/ctxhttp
+  - internal/iana
+  - internal/socket
+  - ipv4
+  - ipv6
 testImports:
 - name: github.com/anmitsu/go-shlex
   version: 648efa622239a2f6ff949fed78ee37b48d499ba4
@@ -100,9 +155,9 @@ testImports:
   subpackages:
   - spew
 - name: github.com/go-playground/overalls
-  version: b52dfefba43cf6f75bb177ba45697ed12e0d10a2
+  version: 364a39b842c5d3772ad0789a24326b9f134e7038
 - name: github.com/golang/lint
-  version: cb00e5669539f047b2f4c53a421a01b0c8e172c6
+  version: c5fb716d6688a859aae56d26d3e6070808df29f7
   subpackages:
   - golint
 - name: github.com/kisielk/errcheck
@@ -112,24 +167,24 @@ testImports:
 - name: github.com/matm/gocov-html
   version: f6dd0fd0ebc7c8cff8b24c0a585caeef250627a3
 - name: github.com/mattn/goveralls
-  version: a99c5ee06aeeca2a2befc7e90b99061b1180850c
+  version: a2cbbd7cdce4f5e051016fedf639c64bb05ef031
 - name: github.com/mvdan/interfacer
-  version: bd42ca7f68d821198f2f3aa564058a57dfe213ac
+  version: 22c51662ff476dfd97944f74db1b263ed920ee83
   subpackages:
   - cmd/interfacer
 - name: github.com/mvdan/lint
-  version: 8349bd8248c3cc6c5f3b61086b37fbb76628f1a9
+  version: c9cbe299b369cbfea16318baaa037b19a69e45d2
 - name: github.com/pmezard/go-difflib
   version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/russross/blackfriday
-  version: 5ebfae50aacdef0dacd1a1acc469c2c1c7a7d4d8
+  version: e7910a813fbd94acce2680899175fa106b7b1787
 - name: github.com/sectioneight/md-to-godoc
-  version: f274e5a4257c85a9eaf60ac820ee813b78cac6ab
+  version: 79157ff08f1acd5c5b1d13d71c0adb7908dbb8a2
 - name: github.com/shurcooL/sanitized_anchor_name
-  version: 1dba4b3954bc059efc3991ec364f9f9a35f597d2
+  version: 541ff5ee47f1dddf6a5281af78307d921524bcb5
 - name: golang.org/x/tools
-  version: d63e2b22b05a9682de336cd4802bba367ed429e7
+  version: 2a5864fcfb595b4ee9a7607f1beb25778cf64c6e
   subpackages:
   - cover

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 6d27efe914b9b5853f9f4f96d1cbc6eaab26d921c201c537306ac6d18f5d7871
-updated: 2017-06-07T14:24:15.561021658-07:00
+updated: 2017-06-07T15:38:52.288658056-07:00
 imports:
 - name: github.com/elodina/go-avro
   version: 0c8185d9a3ba82aeac98db3313a268a5b6df99b5
@@ -26,7 +26,7 @@ imports:
 - name: github.com/uber-go/atomic
   version: 908889c45e73bedd558e99819aea3be3503fc581
 - name: github.com/uber/dosa-idl
-  version: c2232eaffb054442105c493c79a37ff08389e34b
+  version: a887a8e79251bed4bffeaf52a90905b0fb14adbf
   subpackages:
   - .gen
   - .gen/dosa
@@ -136,6 +136,6 @@ testImports:
 - name: github.com/shurcooL/sanitized_anchor_name
   version: 541ff5ee47f1dddf6a5281af78307d921524bcb5
 - name: golang.org/x/tools
-  version: 92d42b9ff15f625347a13b6aeafd04a33537ce91
+  version: 851770f01f04a0a480149de08a871c0378bc3fed
   subpackages:
   - cover

--- a/glide.lock
+++ b/glide.lock
@@ -1,28 +1,14 @@
-hash: 7d1e85d070980bf11cab0f4dc869c2af64ecfaf41b1ccb52eaa5db06184b23ba
-updated: 2017-06-03T12:52:57.781383255-07:00
+hash: 6d27efe914b9b5853f9f4f96d1cbc6eaab26d921c201c537306ac6d18f5d7871
+updated: 2017-06-07T14:24:15.561021658-07:00
 imports:
-- name: github.com/beorn7/perks
-  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
-  subpackages:
-  - quantile
 - name: github.com/elodina/go-avro
   version: 0c8185d9a3ba82aeac98db3313a268a5b6df99b5
-- name: github.com/facebookgo/clock
-  version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
 - name: github.com/golang/mock
   version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
   subpackages:
   - gomock
-- name: github.com/golang/protobuf
-  version: 5a0f697c9ed9d68fef0116532c6e05cfeae00e55
-  subpackages:
-  - proto
 - name: github.com/jessevdk/go-flags
   version: 5695738f733662da3e9afc2283bba6f3c879002d
-- name: github.com/matttproud/golang_protobuf_extensions
-  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
-  subpackages:
-  - pbutil
 - name: github.com/opentracing/opentracing-go
   version: 1949ddbfd147afd4d964a9f00b24eb291e0e7c38
   subpackages:
@@ -30,25 +16,6 @@ imports:
   - log
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
-- name: github.com/prometheus/client_golang
-  version: c5b7fccd204277076155f10851dad72b76a49317
-  subpackages:
-  - prometheus
-  - prometheus/promhttp
-- name: github.com/prometheus/client_model
-  version: 6f3806018612930941127f2a7c6c453ba2c527d2
-  subpackages:
-  - go
-- name: github.com/prometheus/common
-  version: 13ba4ddd0caa9c28ca7b7bffe1dfa9ed8d5ef207
-  subpackages:
-  - expfmt
-  - internal/bitbucket.org/ww/goautoneg
-  - model
-- name: github.com/prometheus/procfs
-  version: 65c1f6f8f0fc1e2185eb9863a3bc751496404259
-  subpackages:
-  - xfs
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/stretchr/testify
@@ -57,9 +24,7 @@ imports:
   - assert
   - mock
 - name: github.com/uber-go/atomic
-  version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
-- name: github.com/uber-go/tally
-  version: e9b601813b0be4771b1b3995390567b67ab2b3fc
+  version: 908889c45e73bedd558e99819aea3be3503fc581
 - name: github.com/uber/dosa-idl
   version: c2232eaffb054442105c493c79a37ff08389e34b
   subpackages:
@@ -77,13 +42,11 @@ imports:
   - trand
   - typed
 - name: github.com/yarpc/yarpc-go
-  version: 6b9245d126758870690c44f27f695cc7e811f913
+  version: 6ae533f0810337028ef055b690360e050aa13219
 - name: github.com/yookoala/realpath
   version: c416d99ab5ed256fa30c1f3bab73152deb59bb69
 - name: go.uber.org/atomic
   version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
-- name: go.uber.org/multierr
-  version: a3d1fc1f1316d4132fc61f4ea1159ae0613fb474
 - name: go.uber.org/thriftrw
   version: dde90c2a40f45fb2b6361d13c1b4bf09465401c0
   subpackages:
@@ -96,7 +59,7 @@ imports:
   - version
   - wire
 - name: go.uber.org/yarpc
-  version: 6b9245d126758870690c44f27f695cc7e811f913
+  version: 6ae533f0810337028ef055b690360e050aa13219
   subpackages:
   - api/encoding
   - api/middleware
@@ -113,10 +76,7 @@ imports:
   - internal/introspection
   - internal/iopool
   - internal/net
-  - internal/observability
   - internal/outboundmiddleware
-  - internal/pally
-  - internal/procedure
   - internal/request
   - internal/sync
   - peer
@@ -124,21 +84,12 @@ imports:
   - transport/http
   - transport/tchannel
   - transport/tchannel/internal
-- name: go.uber.org/zap
-  version: fab453050a7a08c35f31fc5fff6f2dbd962285ab
-  subpackages:
-  - buffer
-  - internal/bufferpool
-  - internal/color
-  - internal/exit
-  - internal/multierror
-  - zapcore
 - name: golang.org/x/net
-  version: e4fa1c5465ad6111f206fc92186b8c83d64adbe1
-  repo: https://github.com/golang/net
+  version: 59a0b19b5533c7977ddeb86b017bf507ed407b12
   subpackages:
   - bpf
   - context
+  - context/ctxhttp
   - internal/iana
   - internal/socket
   - ipv4
@@ -185,6 +136,6 @@ testImports:
 - name: github.com/shurcooL/sanitized_anchor_name
   version: 541ff5ee47f1dddf6a5281af78307d921524bcb5
 - name: golang.org/x/tools
-  version: 2a5864fcfb595b4ee9a7607f1beb25778cf64c6e
+  version: 92d42b9ff15f625347a13b6aeafd04a33537ce91
   subpackages:
   - cover

--- a/glide.yaml
+++ b/glide.yaml
@@ -18,6 +18,10 @@ import:
   - gomock
 - package: github.com/yookoala/realpath
 - package: github.com/jessevdk/go-flags
+
+# github.com/yarpc/yarpc-go and go.uber.org/yarpc are the same thing. Since we _need_ to pin yarpc-go
+# (we directly depend on it), we also pin go.uber.org/yarpc since some of our other dependencies use it.
+# These version pins should always be the same.
 - package: github.com/yarpc/yarpc-go
   version: ~1.7.1
 - package: go.uber.org/yarpc

--- a/glide.yaml
+++ b/glide.yaml
@@ -19,7 +19,9 @@ import:
 - package: github.com/yookoala/realpath
 - package: github.com/jessevdk/go-flags
 - package: github.com/yarpc/yarpc-go
-  version: ^1.7.1
+  version: ~1.7.1
+- package: go.uber.org/yarpc
+  version: ~1.7.1
 testImport:
 - package: golang.org/x/tools
   subpackages:


### PR DESCRIPTION
Just a run of `glide up`. I need the newest version of our generated thrift code so I can use it in our yarpc connector.

This change was originally included in #166 but I'm pulling it out into it's own PR. I'm doing this because @rkuris pointed out that our yarpc dependency also got updated and was concerned about our pinning of it. A look at our `glide.yaml` file reveals we have yarpc pinned to `^1.7.1`. @rkuris does that sound right to you? Or should we pin it to a more fixed version?