### PR TITLE
Validate caller name before invoking YARPC dispatcher

### DIFF
--- a/cmd/dosa/main.go
+++ b/cmd/dosa/main.go
@@ -60,14 +60,14 @@ func (b BuildInfo) Execute(args []string) error {
 
 // GlobalOptions are options for all subcommands
 type GlobalOptions struct {
-	Host        string   `long:"host" default:"127.0.0.1" description:"The hostname or IP for the gateway."`
-	Port        string   `short:"p" long:"port" default:"21300" description:"The hostname or IP for the gateway."`
-	Transport   string   `long:"transport" default:"tchannel" description:"TCP Transport to use. Options: http, tchannel."`
-	ServiceName string   `long:"service" description:"The TChannel service name for the gateway."`
-	CallerName  string   `long:"caller" default:"dosacli-$USER" description:"Caller will override the default caller name (which is dosacli-$USER)."`
-	Timeout     timeFlag `long:"timeout" default:"60s" description:"The timeout for gateway requests. E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds are assumed."`
-	Connector   string   `hidden:"true" long:"connector" default:"yarpc" description:"Name of connector to use"`
-	Version     bool     `long:"version" description:"Display version info"`
+	Host        string     `long:"host" default:"127.0.0.1" description:"The hostname or IP for the gateway."`
+	Port        string     `short:"p" long:"port" default:"21300" description:"The hostname or IP for the gateway."`
+	Transport   string     `long:"transport" default:"tchannel" description:"TCP Transport to use. Options: http, tchannel."`
+	ServiceName string     `long:"service" description:"The TChannel service name for the gateway."`
+	CallerName  callerFlag `long:"caller" default:"dosacli-$USER" description:"Caller will override the default caller name (which is dosacli-$USER)."`
+	Timeout     timeFlag   `long:"timeout" default:"60s" description:"The timeout for gateway requests. E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds are assumed."`
+	Connector   string     `hidden:"true" long:"connector" default:"yarpc" description:"Name of connector to use"`
+	Version     bool       `long:"version" description:"Display version info"`
 }
 
 var (

--- a/cmd/dosa/options.go
+++ b/cmd/dosa/options.go
@@ -42,7 +42,7 @@ var validNameRegex = regexp.MustCompile("^[a-z]+([a-z0-9]|[^-]-)*[^-]$")
 type callerFlag string
 
 func (s *callerFlag) setString(value string) {
-	*s = callerFlag(strings.Replace(value, ".", "_", -1))
+	*s = callerFlag(strings.Replace(value, ".", "-", -1))
 }
 
 // String implements the stringer interface

--- a/cmd/dosa/options.go
+++ b/cmd/dosa/options.go
@@ -23,6 +23,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -34,6 +35,8 @@ const (
 	_prodServiceName = "dosa-gateway"
 	_prodScope       = "production"
 )
+
+var validNameRegex = regexp.MustCompile("^[a-z]+([a-z0-9]|[^-]-)*[^-]$")
 
 type timeFlag time.Duration
 
@@ -68,6 +71,13 @@ func getAdminClient(opts GlobalOptions) (dosa.AdminClient, error) {
 	// fix up the callername
 	if opts.CallerName == "" || opts.CallerName == "dosacli-$USER" {
 		opts.CallerName = fmt.Sprintf("dosacli-%s", os.Getenv("USER"))
+	}
+
+	// from YARPC: "must begin with a letter and consist only of dash-delimited
+	// lower-case ASCII alphanumeric words" -- we do this here because YARPC
+	// will panic if caller name is invalid.
+	if !validNameRegex.MatchString(opts.CallerName) {
+		return nil, fmt.Errorf("invalid caller name: %s, must begin with a letter and consist only of dash-delimited lower-case ASCII alphanumeric words", opts.CallerName)
 	}
 
 	// create connector

--- a/cmd/dosa/options_test.go
+++ b/cmd/dosa/options_test.go
@@ -27,6 +27,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestCallerFlag_String(t *testing.T) {
+	f := callerFlag("")
+	f.setString("foo.bar.baz")
+	assert.Equal(t, "foo_bar_baz", f.String())
+
+	err := f.UnmarshalFlag("qux.quux.corge")
+	assert.NoError(t, err)
+	assert.Equal(t, "qux_quux_corge", f.String())
+}
+
 func TestTimeFlag_Duration(t *testing.T) {
 	sut := timeFlag(0)
 	sut.setDuration(time.Minute)

--- a/cmd/dosa/options_test.go
+++ b/cmd/dosa/options_test.go
@@ -30,11 +30,11 @@ import (
 func TestCallerFlag_String(t *testing.T) {
 	f := callerFlag("")
 	f.setString("foo.bar.baz")
-	assert.Equal(t, "foo_bar_baz", f.String())
+	assert.Equal(t, "foo-bar-baz", f.String())
 
 	err := f.UnmarshalFlag("qux.quux.corge")
 	assert.NoError(t, err)
-	assert.Equal(t, "qux_quux_corge", f.String())
+	assert.Equal(t, "qux-quux-corge", f.String())
 }
 
 func TestTimeFlag_Duration(t *testing.T) {

--- a/cmd/dosa/schema.go
+++ b/cmd/dosa/schema.go
@@ -43,6 +43,22 @@ var (
 	}
 )
 
+type scopeFlag string
+
+func (s *scopeFlag) setString(value string) {
+	*s = scopeFlag(strings.Replace(value, ".", "_", -1))
+}
+
+// String implements the stringer interface
+func (s *scopeFlag) String() string {
+	return string(*s)
+}
+
+func (s *scopeFlag) UnmarshalFlag(value string) error {
+	s.setString(value)
+	return nil
+}
+
 // SchemaOptions contains configuration for schema command flags.
 type SchemaOptions struct {
 	Excludes []string `short:"e" long:"exclude" description:"Exclude files matching pattern."`
@@ -52,8 +68,8 @@ type SchemaOptions struct {
 // SchemaCmd is a placeholder for all schema commands
 type SchemaCmd struct {
 	*SchemaOptions
-	Scope      string `short:"s" long:"scope" description:"Storage scope for the given operation."`
-	NamePrefix string `long:"prefix" description:"Name prefix for schema types." required:"true"`
+	Scope      scopeFlag `short:"s" long:"scope" description:"Storage scope for the given operation."`
+	NamePrefix string    `long:"prefix" description:"Name prefix for schema types." required:"true"`
 }
 
 func (c *SchemaCmd) doSchemaOp(name string, f func(dosa.AdminClient, context.Context, string) (*dosa.SchemaStatus, error), args []string) error {
@@ -86,7 +102,7 @@ func (c *SchemaCmd) doSchemaOp(name string, f func(dosa.AdminClient, context.Con
 		client.Excludes(c.Excludes)
 	}
 	if c.Scope != "" {
-		client.Scope(c.Scope)
+		client.Scope(c.Scope.String())
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), options.Timeout.Duration())
@@ -158,8 +174,8 @@ func (c *SchemaStatus) Execute(args []string) error {
 		return err
 	}
 
-	if c.Scope != "" {
-		client.Scope(c.Scope)
+	if c.Scope.String() != "" {
+		client.Scope(c.Scope.String())
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), options.Timeout.Duration())

--- a/cmd/dosa/schema_test.go
+++ b/cmd/dosa/schema_test.go
@@ -35,6 +35,16 @@ import (
 	_ "github.com/uber-go/dosa/connectors/devnull"
 )
 
+func TestScopeFlag_String(t *testing.T) {
+	f := scopeFlag("")
+	f.setString("foo.bar.baz")
+	assert.Equal(t, "foo_bar_baz", f.String())
+
+	err := f.UnmarshalFlag("qux.quux.corge")
+	assert.NoError(t, err)
+	assert.Equal(t, "qux_quux_corge", f.String())
+}
+
 func TestSchema_ExpandDirectories(t *testing.T) {
 	assert := assert.New(t)
 	const tmpdir = ".testexpanddirectories"

--- a/cmd/dosa/scope_test.go
+++ b/cmd/dosa/scope_test.go
@@ -51,7 +51,6 @@ func TestScope_ServiceDefault(t *testing.T) {
 			os.Args = []string{
 				"dosa",
 				"--service", tc.serviceName,
-				"--caller", "foo.bar",
 				"--connector", "devnull",
 				"scope",
 				cmd,

--- a/cmd/dosa/scope_test.go
+++ b/cmd/dosa/scope_test.go
@@ -51,6 +51,7 @@ func TestScope_ServiceDefault(t *testing.T) {
 			os.Args = []string{
 				"dosa",
 				"--service", tc.serviceName,
+				"--caller", "foo.bar",
 				"--connector", "devnull",
 				"scope",
 				cmd,


### PR DESCRIPTION
RE: [DOSA-1011](https://jira.uberinternal.com/browse/DOSA-1011) - If `$USER` contains invalid characters and subsequently, a caller name result in `dosacli-$USER`, invoking YARPC dispatcher causes a panic. 

To reproduce:
```
USER=evan.culver.test dosa scope create eculver_test # panics
```
To fix the issue, I create two new flag types, one for caller and the other for scope. Each of these flags do the "sanitizing" of incoming values for their respective flag. For caller, '.' is replaced by hyphen (since underscores are not allowed) and for scope, '.' is replaced by underscores.

For example, the example above would create the scope "eculver_test" by calling the dosa-dev-gateway as "dosacli-evan-culver-test".

Similarly for schema operations, this:

```
USER=evan.culver.test dosa schema upsert --prefix personal.eculver ./entities
```

Would attempt to upsert schema found in `./entities` by calling dosa-dev-gateway as "dosa-cli-evan-culver-test" to a scope named "evan_culver_test".
