### PR TITLE
Fix registry and add missing coverage

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -21,7 +21,6 @@
 package dosa
 
 import (
-	"fmt"
 	"reflect"
 
 	"github.com/pkg/errors"
@@ -126,7 +125,7 @@ func (e *RegisteredEntity) OnlyFieldValues(entity DomainObject, fieldNames []str
 	for _, fieldName := range fieldNames {
 		columnName, ok := e.table.FieldToCol[fieldName]
 		if !ok {
-			return nil, fmt.Errorf("%s is not a valid field for %s", fieldName, e.table.StructName)
+			return nil, errors.Errorf("%s is not a valid field for %s", fieldName, e.table.StructName)
 		}
 		value := v.FieldByName(fieldName)
 		if !value.IsValid() {
@@ -149,7 +148,7 @@ func (e *RegisteredEntity) ColumnNames(fieldNames []string) ([]string, error) {
 	for i, fieldName := range fieldNames {
 		columnName, ok := e.table.FieldToCol[fieldName]
 		if !ok {
-			return nil, fmt.Errorf("%s is not a valid field for %s", fieldName, e.table.StructName)
+			return nil, errors.Errorf("%s is not a valid field for %s", fieldName, e.table.StructName)
 		}
 		columnNames[i] = columnName
 	}
@@ -275,7 +274,7 @@ func (r *prefixedRegistrar) FindAll() ([]*RegisteredEntity, error) {
 		res = append(res, re)
 	}
 	if len(res) == 0 {
-		return nil, fmt.Errorf("registry.FindAll returned empty")
+		return nil, errors.Errorf("registry.FindAll returned empty")
 	}
 	return res, nil
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -21,7 +21,6 @@
 package registry
 
 import (
-	"fmt"
 	"reflect"
 
 	"github.com/pkg/errors"
@@ -65,7 +64,7 @@ func (r *registrar) FindAll() ([]*dosa.RegisteredEntity, error) {
 		res = append(res, re)
 	}
 	if len(res) == 0 {
-		return nil, fmt.Errorf("registry.FindAll returned empty")
+		return nil, errors.New("registry.FindAll returned empty")
 	}
 	return res, nil
 }
@@ -74,18 +73,18 @@ func (r *registrar) FindAll() ([]*dosa.RegisteredEntity, error) {
 func NewRegistrar(cfg *config.Config) (dosa.Registrar, error) {
 	idx := make(map[dosa.FQN]*dosa.RegisteredEntity)
 	baseFQN, err := dosa.ToFQN(cfg.NamePrefix)
+	// invalid prefix/FQN
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to construct Registrar")
 	}
-
 	// "warnings" mean entity was found but contained invalid annotations
 	eds, warns, err := dosa.FindEntities(cfg.EntityPaths, cfg.Excludes)
-	if len(warns) > 0 {
-		return nil, dosa.NewEntityErrors(warns)
-	}
 	// I/O and AST parsing errors
 	if err != nil {
 		return nil, err
+	}
+	if len(warns) > 0 {
+		return nil, dosa.NewEntityErrors(warns)
 	}
 
 	// index entity definitions (aka "tables")

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -49,7 +49,7 @@ func (r *registrar) NamePrefix() string {
 // Find looks at its internal index to find a registration that matches the
 // entity instance provided. Return an error when not found.
 func (r *registrar) Find(entity dosa.DomainObject) (*dosa.RegisteredEntity, error) {
-	name := reflect.TypeOf(entity).Name()
+	name := reflect.TypeOf(entity).Elem().Name()
 	fqn, _ := r.baseFQN.Child(name)
 	re, ok := r.idx[fqn]
 	if !ok {


### PR DESCRIPTION
This fixes a bug where the new registry package used for auto-discovery wasn't dereferencing correctly. Along the way, I noticed that we were using `fmt.Errorf` in a couple places so I went ahead and replaced them with `errors.Errorf`. And I added missing test coverage.