### PR TITLE
[easy] fix error message wraping

### DIFF
--- a/client.go
+++ b/client.go
@@ -421,12 +421,12 @@ func (c *client) ScanEverything(ctx context.Context, sop *ScanOp) ([]DomainObjec
 	// look up the entity in the registry
 	re, err := c.registrar.Find(sop.object)
 	if err != nil {
-		return nil, "", errors.Wrap(err, "Range")
+		return nil, "", errors.Wrap(err, "ScanEverything")
 	}
 	// convert the fieldsToRead to the server side equivalent
 	fieldsToRead, err := re.ColumnNames(sop.fieldsToRead)
 	if err != nil {
-		return nil, "", errors.Wrap(err, "Range")
+		return nil, "", errors.Wrap(err, "ScanEverything")
 	}
 
 	// call the server side method

--- a/client.go
+++ b/client.go
@@ -421,12 +421,12 @@ func (c *client) ScanEverything(ctx context.Context, sop *ScanOp) ([]DomainObjec
 	// look up the entity in the registry
 	re, err := c.registrar.Find(sop.object)
 	if err != nil {
-		return nil, "", errors.Wrap(err, "ScanEverything")
+		return nil, "", errors.Wrap(err, "failed to ScanEverything")
 	}
 	// convert the fieldsToRead to the server side equivalent
 	fieldsToRead, err := re.ColumnNames(sop.fieldsToRead)
 	if err != nil {
-		return nil, "", errors.Wrap(err, "ScanEverything")
+		return nil, "", errors.Wrap(err, "failed to ScanEverything")
 	}
 
 	// call the server side method


### PR DESCRIPTION
Looks like there was some copy pasta when wrapping errors for the `ScanEverything` function. Let's fix these wraps and save some developer sanity.