### PR TITLE
Add nulltypes to parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,8 @@ vendor/
 # JIRA plugin
 atlassian-ide-plugin.xml
 
+# VSCode
+.vscode/
 # Crashlytics plugin (for Android Studio and IntelliJ)
 com_crashlytics_export_strings.xml
 crashlytics.properties

--- a/.gitignore
+++ b/.gitignore
@@ -81,8 +81,6 @@ vendor/
 # JIRA plugin
 atlassian-ide-plugin.xml
 
-# VSCode
-.vscode/
 # Crashlytics plugin (for Android Studio and IntelliJ)
 com_crashlytics_export_strings.xml
 crashlytics.properties
@@ -171,6 +169,13 @@ cscope.out
 cscope.in.out
 cscope.po.out
 
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
 
 # End of https://www.gitignore.io/api/go,node,intellij+iml,tags
 

--- a/cmd/dosa/schema_test.go
+++ b/cmd/dosa/schema_test.go
@@ -278,6 +278,14 @@ func TestSchema_Upsert_Happy(t *testing.T) {
 	exit = func(r int) {
 		assert.Equal(t, 0, r)
 	}
+
+	nameMap := map[string]bool{
+		"awesome_test_entity":           true,
+		"testnullableentity":            true,
+		"named_import_entity":           true,
+		"testnullablenamedimportentity": true,
+	}
+
 	dosa.RegisterConnector("mock", func(dosa.CreationArgs) (dosa.Connector, error) {
 		mc := mocks.NewMockConnector(ctrl)
 		mc.EXPECT().UpsertSchema(gomock.Any(), "scope", "foo", gomock.Any()).
@@ -286,7 +294,10 @@ func TestSchema_Upsert_Happy(t *testing.T) {
 				assert.True(t, ok)
 				assert.True(t, dl.After(time.Now()))
 				assert.Equal(t, 4, len(ed))
-				assert.Equal(t, "awesome_test_entity", ed[0].Name)
+
+				for _, e := range ed {
+					assert.True(t, nameMap[e.Name])
+				}
 			}).Return(&dosa.SchemaStatus{Version: int32(1)}, nil)
 		return mc, nil
 	})

--- a/cmd/dosa/schema_test.go
+++ b/cmd/dosa/schema_test.go
@@ -35,6 +35,15 @@ import (
 	_ "github.com/uber-go/dosa/connectors/devnull"
 )
 
+func getTestEntityNameMap() map[string]bool {
+	return map[string]bool{
+		"awesome_test_entity":           true,
+		"testnullableentity":            true,
+		"named_import_entity":           true,
+		"testnullablenamedimportentity": true,
+	}
+}
+
 func TestSchema_ExpandDirectories(t *testing.T) {
 	assert := assert.New(t)
 	const tmpdir = ".testexpanddirectories"
@@ -241,7 +250,10 @@ func TestSchema_Check_Happy(t *testing.T) {
 				assert.True(t, ok)
 				assert.True(t, dl.After(time.Now()))
 				assert.Equal(t, 4, len(ed))
-				assert.Equal(t, "awesome_test_entity", ed[0].Name)
+				nameMap := getTestEntityNameMap()
+				for _, e := range ed {
+					assert.True(t, nameMap[e.Name])
+				}
 			}).Return(int32(1), nil)
 		return mc, nil
 	})
@@ -279,13 +291,6 @@ func TestSchema_Upsert_Happy(t *testing.T) {
 		assert.Equal(t, 0, r)
 	}
 
-	nameMap := map[string]bool{
-		"awesome_test_entity":           true,
-		"testnullableentity":            true,
-		"named_import_entity":           true,
-		"testnullablenamedimportentity": true,
-	}
-
 	dosa.RegisterConnector("mock", func(dosa.CreationArgs) (dosa.Connector, error) {
 		mc := mocks.NewMockConnector(ctrl)
 		mc.EXPECT().UpsertSchema(gomock.Any(), "scope", "foo", gomock.Any()).
@@ -295,6 +300,7 @@ func TestSchema_Upsert_Happy(t *testing.T) {
 				assert.True(t, dl.After(time.Now()))
 				assert.Equal(t, 4, len(ed))
 
+				nameMap := getTestEntityNameMap()
 				for _, e := range ed {
 					assert.True(t, nameMap[e.Name])
 				}

--- a/cmd/dosa/schema_test.go
+++ b/cmd/dosa/schema_test.go
@@ -212,6 +212,7 @@ func TestSchema_NoEntitiesFound(t *testing.T) {
 		}
 		os.Args = append(os.Args, []string{
 			"-e", "testentity.go",
+			"-e", "named_import_testentity.go",
 			"../../testentity",
 		}...)
 		main()

--- a/cmd/dosa/schema_test.go
+++ b/cmd/dosa/schema_test.go
@@ -239,7 +239,7 @@ func TestSchema_Check_Happy(t *testing.T) {
 				dl, ok := ctx.Deadline()
 				assert.True(t, ok)
 				assert.True(t, dl.After(time.Now()))
-				assert.Equal(t, 2, len(ed))
+				assert.Equal(t, 4, len(ed))
 				assert.Equal(t, "awesome_test_entity", ed[0].Name)
 			}).Return(int32(1), nil)
 		return mc, nil
@@ -284,7 +284,7 @@ func TestSchema_Upsert_Happy(t *testing.T) {
 				dl, ok := ctx.Deadline()
 				assert.True(t, ok)
 				assert.True(t, dl.After(time.Now()))
-				assert.Equal(t, 2, len(ed))
+				assert.Equal(t, 4, len(ed))
 				assert.Equal(t, "awesome_test_entity", ed[0].Name)
 			}).Return(&dosa.SchemaStatus{Version: int32(1)}, nil)
 		return mc, nil

--- a/cmd/dosa/schema_test.go
+++ b/cmd/dosa/schema_test.go
@@ -42,6 +42,7 @@ func getTestEntityNameMap() map[string]bool {
 		"named_import_entity":           true,
 		"testnullablenamedimportentity": true,
 	}
+}
 
 func TestScopeFlag_String(t *testing.T) {
 	f := scopeFlag("")

--- a/cmd/dosa/schema_test.go
+++ b/cmd/dosa/schema_test.go
@@ -239,7 +239,7 @@ func TestSchema_Check_Happy(t *testing.T) {
 				dl, ok := ctx.Deadline()
 				assert.True(t, ok)
 				assert.True(t, dl.After(time.Now()))
-				assert.Equal(t, 1, len(ed))
+				assert.Equal(t, 2, len(ed))
 				assert.Equal(t, "awesome_test_entity", ed[0].Name)
 			}).Return(int32(1), nil)
 		return mc, nil
@@ -284,7 +284,7 @@ func TestSchema_Upsert_Happy(t *testing.T) {
 				dl, ok := ctx.Deadline()
 				assert.True(t, ok)
 				assert.True(t, dl.After(time.Now()))
-				assert.Equal(t, 1, len(ed))
+				assert.Equal(t, 2, len(ed))
 				assert.Equal(t, "awesome_test_entity", ed[0].Name)
 			}).Return(&dosa.SchemaStatus{Version: int32(1)}, nil)
 		return mc, nil

--- a/connectors/yarpc/helpers.go
+++ b/connectors/yarpc/helpers.go
@@ -149,7 +149,7 @@ func RPCTypeToClientType(t dosarpc.ElemType) dosa.Type {
 		return dosa.Timestamp
 	case dosarpc.ElemTypeUUID:
 		return dosa.TUUID
-	//TODO: UmerAzad - Handle conversation into Nullable types.
+		//TODO: UmerAzad - Handle conversation into Nullable types.
 	}
 	panic("bad type")
 }

--- a/connectors/yarpc/helpers.go
+++ b/connectors/yarpc/helpers.go
@@ -35,19 +35,19 @@ func RawValueAsInterface(val dosarpc.RawValue, typ dosa.Type) interface{} {
 	case dosa.TUUID:
 		uuid, _ := dosa.BytesToUUID(val.BinaryValue) // TODO: should we handle this error?
 		return uuid
-	case dosa.String:
+	case dosa.String, dosa.TNullString:
 		return *val.StringValue
 	case dosa.Int32:
 		return *val.Int32Value
-	case dosa.Int64:
+	case dosa.Int64, dosa.TNullInt64:
 		return *val.Int64Value
-	case dosa.Double:
+	case dosa.Double, dosa.TNullFloat64:
 		return *val.DoubleValue
 	case dosa.Blob:
 		return val.BinaryValue
 	case dosa.Timestamp:
 		return time.Unix(0, *val.Int64Value)
-	case dosa.Bool:
+	case dosa.Bool, dosa.TNullBool:
 		return *val.BoolValue
 	}
 	panic("bad type")
@@ -86,6 +86,15 @@ func RawValueFromInterface(i interface{}) (*dosarpc.RawValue, error) {
 			return nil, err
 		}
 		return &dosarpc.RawValue{BinaryValue: bytes}, nil
+	// TODO: (UmerAzad) Deal with nil values once NullTime and NullUUID are added. It'll be covered as part of JIRA-927.
+	case dosa.NullString:
+		return &dosarpc.RawValue{StringValue: &v.String}, nil
+	case dosa.NullInt64:
+		return &dosarpc.RawValue{Int64Value: &v.Int64}, nil
+	case dosa.NullFloat64:
+		return &dosarpc.RawValue{DoubleValue: &v.Float64}, nil
+	case dosa.NullBool:
+		return &dosarpc.RawValue{BoolValue: &v.Bool}, nil
 	}
 	panic("bad type")
 }
@@ -109,6 +118,14 @@ func RPCTypeFromClientType(t dosa.Type) dosarpc.ElemType {
 		return dosarpc.ElemTypeTimestamp
 	case dosa.TUUID:
 		return dosarpc.ElemTypeUUID
+	case dosa.TNullBool:
+		return dosarpc.ElemTypeBool
+	case dosa.TNullInt64:
+		return dosarpc.ElemTypeInt64
+	case dosa.TNullFloat64:
+		return dosarpc.ElemTypeDouble
+	case dosa.TNullString:
+		return dosarpc.ElemTypeString
 	}
 	panic("bad type")
 }
@@ -132,6 +149,7 @@ func RPCTypeToClientType(t dosarpc.ElemType) dosa.Type {
 		return dosa.Timestamp
 	case dosarpc.ElemTypeUUID:
 		return dosa.TUUID
+	//TODO: UmerAzad - Handle conversation into Nullable types.
 	}
 	panic("bad type")
 }

--- a/doc.go
+++ b/doc.go
@@ -22,13 +22,13 @@
 //
 // Abstract
 //
-// :warning: DOSA is *BETA* software. It is not recommended for production use.
+// :warning: DOSA is BETA software. It is not recommended for production use.
 // We will announce when it's ready.
 //
 //
 // DOSA (https://github.com/uber-go/dosa/wiki) is a storage framework that
 // provides a
-// *delcarative object storage abstraction* for applications in Golang
+// delcarative object storage abstraction for applications in Golang
 // and (eventually) Java. DOSA is designed to relieve common headaches developers
 // face while building stateful, database-dependent services.
 //

--- a/entity.go
+++ b/entity.go
@@ -178,7 +178,7 @@ func (e *EntityDefinition) EnsureValid() error {
 	}
 
 	if err := e.ensureNonNullablePrimaryKeys(); err != nil {
-		return errors.Wrap(err, "Nullable types are not allowed as primary key(s)")
+		return err
 	}
 
 	return nil
@@ -188,13 +188,13 @@ func (e *EntityDefinition) ensureNonNullablePrimaryKeys() error {
 	columnTypes := e.ColumnTypes()
 
 	for k := range e.PartitionKeySet() {
-		if isValidPrimaryKeyType(columnTypes[k]) {
+		if isInvalidPrimaryKeyType(columnTypes[k]) {
 			return errors.Errorf("primary key is of nullable type: %q", k)
 		}
 	}
 
 	for k := range e.ClusteringKeySet() {
-		if isValidPrimaryKeyType(columnTypes[k]) {
+		if isInvalidPrimaryKeyType(columnTypes[k]) {
 			return errors.Errorf("clustering key is of nullable type: %q", k)
 		}
 	}

--- a/entity.go
+++ b/entity.go
@@ -187,15 +187,15 @@ func (e *EntityDefinition) EnsureValid() error {
 func (e *EntityDefinition) ensureNonNullablePrimaryKeys() error {
 	columnTypes := e.ColumnTypes()
 
-	for k, _ := range e.PartitionKeySet() {
+	for k := range e.PartitionKeySet() {
 		if isNullableType(columnTypes[k]) {
-			return errors.Errorf("primary key %q is of nullable type: %q", k)
+			return errors.Errorf("primary key is of nullable type: %q", k)
 		}
 	}
 
-	for k, _ := range e.ClusteringKeySet() {
+	for k := range e.ClusteringKeySet() {
 		if isNullableType(columnTypes[k]) {
-			return errors.Errorf("clustering key %q is of nullable type: %q", k)
+			return errors.Errorf("clustering key is of nullable type: %q", k)
 		}
 	}
 	return nil

--- a/entity.go
+++ b/entity.go
@@ -177,6 +177,27 @@ func (e *EntityDefinition) EnsureValid() error {
 		keyNamesSeen[c.Name] = struct{}{}
 	}
 
+	if err := e.ensureNonNullablePrimaryKeys(); err != nil {
+		return errors.Wrap(err, "Nullable types are not allowed as primary key(s)")
+	}
+
+	return nil
+}
+
+func (e *EntityDefinition) ensureNonNullablePrimaryKeys() error {
+	columnTypes := e.ColumnTypes()
+
+	for k, _ := range e.PartitionKeySet() {
+		if isNullableType(columnTypes[k]) {
+			return errors.Errorf("primary key %q is of nullable type: %q", k)
+		}
+	}
+
+	for k, _ := range e.ClusteringKeySet() {
+		if isNullableType(columnTypes[k]) {
+			return errors.Errorf("clustering key %q is of nullable type: %q", k)
+		}
+	}
 	return nil
 }
 

--- a/entity.go
+++ b/entity.go
@@ -188,13 +188,13 @@ func (e *EntityDefinition) ensureNonNullablePrimaryKeys() error {
 	columnTypes := e.ColumnTypes()
 
 	for k := range e.PartitionKeySet() {
-		if isNullableType(columnTypes[k]) {
+		if isValidPrimaryKeyType(columnTypes[k]) {
 			return errors.Errorf("primary key is of nullable type: %q", k)
 		}
 	}
 
 	for k := range e.ClusteringKeySet() {
-		if isNullableType(columnTypes[k]) {
+		if isValidPrimaryKeyType(columnTypes[k]) {
 			return errors.Errorf("clustering key is of nullable type: %q", k)
 		}
 	}

--- a/entity_parser.go
+++ b/entity_parser.go
@@ -213,7 +213,7 @@ func TableFromInstance(object DomainObject) (*Table, error) {
 	return t, nil
 }
 
-// primaryKeyNameMatch translate the primary keys to the internal column name based on the maping
+// translateKeyName translate the primary keys to the internal column name based on the mapping
 // between fields and columns.
 func translateKeyName(t *Table) {
 	pk := t.EntityDefinition.Key

--- a/entity_parser.go
+++ b/entity_parser.go
@@ -311,14 +311,18 @@ func parseField(typ Type, name string, tag string) (*ColumnDefinition, error) {
 }
 
 var (
-	uuidType      = reflect.TypeOf(UUID(""))
-	blobType      = reflect.TypeOf([]byte{})
-	timestampType = reflect.TypeOf(time.Time{})
-	int32Type     = reflect.TypeOf(int32(0))
-	int64Type     = reflect.TypeOf(int64(0))
-	doubleType    = reflect.TypeOf(float64(0.0))
-	stringType    = reflect.TypeOf("")
-	boolType      = reflect.TypeOf(true)
+	uuidType        = reflect.TypeOf(UUID(""))
+	blobType        = reflect.TypeOf([]byte{})
+	timestampType   = reflect.TypeOf(time.Time{})
+	int32Type       = reflect.TypeOf(int32(0))
+	int64Type       = reflect.TypeOf(int64(0))
+	doubleType      = reflect.TypeOf(float64(0.0))
+	stringType      = reflect.TypeOf("")
+	boolType        = reflect.TypeOf(true)
+	nullBoolType    = reflect.TypeOf(NullBool{})
+	nullInt64Type   = reflect.TypeOf(NullInt64{})
+	nullFloat64Type = reflect.TypeOf(NullFloat64{})
+	nullStringType  = reflect.TypeOf(NullString{})
 )
 
 func typify(f reflect.Type) (Type, error) {
@@ -339,6 +343,14 @@ func typify(f reflect.Type) (Type, error) {
 		return String, nil
 	case boolType:
 		return Bool, nil
+	case nullStringType:
+		return TNullString, nil
+	case nullInt64Type:
+		return TNullInt64, nil
+	case nullFloat64Type:
+		return TNullFloat64, nil
+	case nullBoolType:
+		return TNullBool, nil
 	}
 
 	return Invalid, fmt.Errorf("Invalid type %v", f)

--- a/entity_parser_test.go
+++ b/entity_parser_test.go
@@ -311,7 +311,7 @@ func TestNullStringPrimaryKeyType(t *testing.T) {
 	dosaTable, err := TableFromInstance(&NullStringPrimaryKeyType{})
 	assert.Nil(t, dosaTable)
 	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "Nullable types are not allowed")
+	assert.Contains(t, err.Error(), "primary key is of nullable type")
 }
 
 type NullInt64PrimaryKeyType struct {
@@ -323,7 +323,7 @@ func TestNullInt64PrimaryKeyType(t *testing.T) {
 	dosaTable, err := TableFromInstance(&NullInt64PrimaryKeyType{})
 	assert.Nil(t, dosaTable)
 	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "Nullable types are not allowed")
+	assert.Contains(t, err.Error(), "primary key is of nullable type")
 }
 
 type NullFloat64PrimaryKeyType struct {
@@ -335,7 +335,7 @@ func TestNullFloat64PrimaryKeyType(t *testing.T) {
 	dosaTable, err := TableFromInstance(&NullFloat64PrimaryKeyType{})
 	assert.Nil(t, dosaTable)
 	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "Nullable types are not allowed")
+	assert.Contains(t, err.Error(), "primary key is of nullable type")
 }
 
 type NullBoolPrimaryKeyType struct {
@@ -347,7 +347,7 @@ func TestNullBoolPrimaryKeyType(t *testing.T) {
 	dosaTable, err := TableFromInstance(&NullBoolPrimaryKeyType{})
 	assert.Nil(t, dosaTable)
 	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "Nullable types are not allowed")
+	assert.Contains(t, err.Error(), "primary key is of nullable type")
 }
 
 type KeyFieldNameTypo struct {

--- a/entity_parser_test.go
+++ b/entity_parser_test.go
@@ -303,7 +303,7 @@ func TestUnsupportedType(t *testing.T) {
 }
 
 type NullStringPrimaryKeyType struct {
-	Entity    `dosa:"primaryKey=NullStringType"`
+	Entity         `dosa:"primaryKey=NullStringType"`
 	NullStringType NullString
 }
 
@@ -315,7 +315,7 @@ func TestNullStringPrimaryKeyType(t *testing.T) {
 }
 
 type NullInt64PrimaryKeyType struct {
-	Entity    `dosa:"primaryKey=NullInt64Type"`
+	Entity        `dosa:"primaryKey=NullInt64Type"`
 	NullInt64Type NullInt64
 }
 
@@ -327,7 +327,7 @@ func TestNullInt64PrimaryKeyType(t *testing.T) {
 }
 
 type NullFloat64PrimaryKeyType struct {
-	Entity    `dosa:"primaryKey=NullFloat64Type"`
+	Entity          `dosa:"primaryKey=NullFloat64Type"`
 	NullFloat64Type NullFloat64
 }
 
@@ -339,7 +339,7 @@ func TestNullFloat64PrimaryKeyType(t *testing.T) {
 }
 
 type NullBoolPrimaryKeyType struct {
-	Entity    `dosa:"primaryKey=NullBoolType"`
+	Entity       `dosa:"primaryKey=NullBoolType"`
 	NullBoolType NullBool
 }
 

--- a/entity_parser_test.go
+++ b/entity_parser_test.go
@@ -302,6 +302,54 @@ func TestUnsupportedType(t *testing.T) {
 	assert.Contains(t, err.Error(), "UnsupType")
 }
 
+type NullStringPrimaryKeyType struct {
+	Entity    `dosa:"primaryKey=NullStringType"`
+	NullStringType NullString
+}
+
+func TestNullStringPrimaryKeyType(t *testing.T) {
+	dosaTable, err := TableFromInstance(&NullStringPrimaryKeyType{})
+	assert.Nil(t, dosaTable)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Nullable types are not allowed")
+}
+
+type NullInt64PrimaryKeyType struct {
+	Entity    `dosa:"primaryKey=NullInt64Type"`
+	NullInt64Type NullInt64
+}
+
+func TestNullInt64PrimaryKeyType(t *testing.T) {
+	dosaTable, err := TableFromInstance(&NullInt64PrimaryKeyType{})
+	assert.Nil(t, dosaTable)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Nullable types are not allowed")
+}
+
+type NullFloat64PrimaryKeyType struct {
+	Entity    `dosa:"primaryKey=NullFloat64Type"`
+	NullFloat64Type NullFloat64
+}
+
+func TestNullFloat64PrimaryKeyType(t *testing.T) {
+	dosaTable, err := TableFromInstance(&NullFloat64PrimaryKeyType{})
+	assert.Nil(t, dosaTable)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Nullable types are not allowed")
+}
+
+type NullBoolPrimaryKeyType struct {
+	Entity    `dosa:"primaryKey=NullBoolType"`
+	NullBoolType NullBool
+}
+
+func TestNullBoolPrimaryKeyType(t *testing.T) {
+	dosaTable, err := TableFromInstance(&NullBoolPrimaryKeyType{})
+	assert.Nil(t, dosaTable)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Nullable types are not allowed")
+}
+
 type KeyFieldNameTypo struct {
 	Entity   `dosa:"primaryKey=BoolHype"`
 	BoolType bool

--- a/entity_parser_test.go
+++ b/entity_parser_test.go
@@ -198,23 +198,27 @@ func TestMissingAnnotation(t *testing.T) {
 }
 
 type AllTypes struct {
-	Entity     `dosa:"primaryKey=BoolType"`
-	BoolType   bool
-	Int32Type  int32
-	Int64Type  int64
-	DoubleType float64
-	StringType string
-	BlobType   []byte
-	TimeType   time.Time
-	UUIDType   UUID
+	Entity          `dosa:"primaryKey=BoolType"`
+	BoolType        bool
+	Int32Type       int32
+	Int64Type       int64
+	DoubleType      float64
+	StringType      string
+	BlobType        []byte
+	TimeType        time.Time
+	UUIDType        UUID
+	NullStringType  NullString
+	NullInt64Type   NullInt64
+	NullFloat64Type NullFloat64
+	NullBoolType    NullBool
 }
 
 func TestAllTypes(t *testing.T) {
 	dosaTable, err := TableFromInstance(&AllTypes{})
 	assert.NotNil(t, dosaTable)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	cds := dosaTable.Columns
-	assert.Len(t, cds, 8)
+	assert.Len(t, cds, 12)
 	for _, cd := range cds {
 		name, err := NormalizeName(cd.Name)
 		assert.NoError(t, err)
@@ -235,6 +239,49 @@ func TestAllTypes(t *testing.T) {
 			assert.Equal(t, Timestamp, cd.Type)
 		case "uuidtype":
 			assert.Equal(t, TUUID, cd.Type)
+		case "nullbooltype":
+			assert.Equal(t, TNullBool, cd.Type)
+		case "nullint64type":
+			assert.Equal(t, TNullInt64, cd.Type)
+		case "nullfloat64type":
+			assert.Equal(t, TNullFloat64, cd.Type)
+		case "nullstringtype":
+			assert.Equal(t, TNullString, cd.Type)
+		default:
+			assert.Fail(t, "unexpected column name", name)
+		}
+	}
+}
+
+type NullableType struct {
+	Entity          `dosa:"primaryKey=BoolType"`
+	BoolType        bool
+	NullStringType  NullString
+	NullInt64Type   NullInt64
+	NullFloat64Type NullFloat64
+	NullBoolType    NullBool
+}
+
+func TestNullableType(t *testing.T) {
+	dosaTable, err := TableFromInstance(&NullableType{})
+	assert.NoError(t, err)
+	assert.NotNil(t, dosaTable)
+	cds := dosaTable.Columns
+	assert.Len(t, cds, 5)
+	for _, cd := range cds {
+		name, err := NormalizeName(cd.Name)
+		assert.NoError(t, err)
+		switch name {
+		case "booltype":
+			assert.Equal(t, Bool, cd.Type)
+		case "nullbooltype":
+			assert.Equal(t, TNullBool, cd.Type)
+		case "nullint64type":
+			assert.Equal(t, TNullInt64, cd.Type)
+		case "nullfloat64type":
+			assert.Equal(t, TNullFloat64, cd.Type)
+		case "nullstringtype":
+			assert.Equal(t, TNullString, cd.Type)
 		default:
 			assert.Fail(t, "unexpected column name", name)
 		}

--- a/entity_test.go
+++ b/entity_test.go
@@ -354,3 +354,4 @@ func TestEntityDefinition_FindColumnDefinition(t *testing.T) {
 	assert.Nil(t, ed.FindColumnDefinition("notacolumn"))
 
 }
+

--- a/entity_test.go
+++ b/entity_test.go
@@ -354,4 +354,3 @@ func TestEntityDefinition_FindColumnDefinition(t *testing.T) {
 	assert.Nil(t, ed.FindColumnDefinition("notacolumn"))
 
 }
-

--- a/finder.go
+++ b/finder.go
@@ -222,7 +222,7 @@ func tableFromStructType(structName string, structType *ast.StructType, packageP
 					// skip unexported fields
 					continue
 				}
-				typ := stringToDosaType(kind)
+				typ := stringToDosaType(kind, packagePrefix)
 				if typ == Invalid {
 					return nil, fmt.Errorf("Column %q has invalid type %q", name, kind)
 				}
@@ -248,7 +248,13 @@ func tableFromStructType(structName string, structType *ast.StructType, packageP
 	return t, nil
 }
 
-func stringToDosaType(inType string) Type {
+func stringToDosaType(inType, pkg string) Type {
+
+	// Append a dot if the package suffix doesn't already have one.
+	if pkg != "" && !strings.HasSuffix(pkg, ".") {
+		pkg += "."
+	}
+
 	switch inType {
 	case "string":
 		return String
@@ -264,15 +270,15 @@ func stringToDosaType(inType string) Type {
 		return Double
 	case "time.Time":
 		return Timestamp
-	case "UUID", "dosa.UUID":
+	case "UUID", pkg + "UUID":
 		return TUUID
-	case "NullString", "dosa.NullString":
+	case "NullString", pkg + "NullString":
 		return TNullString
-	case "NullInt64", "dosa.NullInt64":
+	case "NullInt64", pkg + "NullInt64":
 		return TNullInt64
-	case "NullFloat64", "dosa.NullFloat64":
+	case "NullFloat64", pkg + "NullFloat64":
 		return TNullFloat64
-	case "NullBool", "dosa.NullBool":
+	case "NullBool", pkg + "NullBool":
 		return TNullBool
 	default:
 		return Invalid

--- a/finder.go
+++ b/finder.go
@@ -222,7 +222,7 @@ func tableFromStructType(structName string, structType *ast.StructType, packageP
 					// skip unexported fields
 					continue
 				}
-				typ := stringToDosaType(kind, packagePrefix)
+				typ := stringToDosaType(kind)
 				if typ == Invalid {
 					return nil, fmt.Errorf("Column %q has invalid type %q", name, kind)
 				}
@@ -248,12 +248,7 @@ func tableFromStructType(structName string, structType *ast.StructType, packageP
 	return t, nil
 }
 
-func stringToDosaType(inType string, packagePrefix string) Type {
-	// Append a dot if the package suffix doesn't already have one.
-	if packagePrefix != "" && !strings.HasSuffix(packagePrefix, ".") {
-		packagePrefix += "."
-	}
-
+func stringToDosaType(inType string) Type {
 	switch inType {
 	case "string":
 		return String
@@ -269,15 +264,15 @@ func stringToDosaType(inType string, packagePrefix string) Type {
 		return Double
 	case "time.Time":
 		return Timestamp
-	case packagePrefix + "UUID":
+	case "UUID", "dosa.UUID":
 		return TUUID
-	case packagePrefix + "NullString":
+	case "NullString", "dosa.NullString":
 		return TNullString
-	case packagePrefix + "NullInt64":
+	case "NullInt64", "dosa.NullInt64":
 		return TNullInt64
-	case packagePrefix + "NullFloat64":
+	case "NullFloat64", "dosa.NullFloat64":
 		return TNullFloat64
-	case packagePrefix + "NullBool":
+	case "NullBool", "dosa.NullBool":
 		return TNullBool
 	default:
 		return Invalid

--- a/finder.go
+++ b/finder.go
@@ -206,6 +206,8 @@ func tableFromStructType(structName string, structType *ast.StructType, packageP
 			if innerName, ok := typeName.X.(*ast.Ident); ok {
 				kind = innerName.Name + "." + typeName.Sel.Name
 			}
+		default:
+			return nil, fmt.Errorf("Unexpected field type: %q", typeName)
 		}
 		if kind == packagePrefix+"."+entityName || (packagePrefix == "" && kind == entityName) {
 			var err error
@@ -247,6 +249,11 @@ func tableFromStructType(structName string, structType *ast.StructType, packageP
 }
 
 func stringToDosaType(inType string, packagePrefix string) Type {
+	// Append a dot if the package suffix doesn't already have one.
+	if packagePrefix != "" && !strings.HasPrefix(packagePrefix, ".") {
+		packagePrefix += "."
+	}
+
 	switch inType {
 	case "string":
 		return String
@@ -262,8 +269,16 @@ func stringToDosaType(inType string, packagePrefix string) Type {
 		return Double
 	case "time.Time":
 		return Timestamp
-	case packagePrefix + ".UUID":
+	case packagePrefix + "UUID":
 		return TUUID
+	case packagePrefix + "NullString":
+		return TNullString
+	case packagePrefix + "NullInt64":
+		return TNullInt64
+	case packagePrefix + "NullFloat64":
+		return TNullFloat64
+	case packagePrefix + "NullBool":
+		return TNullBool
 	default:
 		return Invalid
 	}

--- a/finder.go
+++ b/finder.go
@@ -250,7 +250,7 @@ func tableFromStructType(structName string, structType *ast.StructType, packageP
 
 func stringToDosaType(inType string, packagePrefix string) Type {
 	// Append a dot if the package suffix doesn't already have one.
-	if packagePrefix != "" && !strings.HasPrefix(packagePrefix, ".") {
+	if packagePrefix != "" && !strings.HasSuffix(packagePrefix, ".") {
 		packagePrefix += "."
 	}
 

--- a/finder_test.go
+++ b/finder_test.go
@@ -89,6 +89,8 @@ func TestParser(t *testing.T) {
 			continue
 		case "registrytestvalid": // skip, same as above
 			continue
+		case "alltypesscantestentity": // skipping test entity defined in scan_test.go
+			continue
 		default:
 			t.Errorf("entity %s not expected", entity.Name)
 			continue
@@ -115,5 +117,48 @@ func TestFindEntitiesInOtherPkg(t *testing.T) {
 func BenchmarkFinder(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		FindEntities([]string{"."}, []string{})
+	}
+}
+
+func TestStringToDosaType(t *testing.T) {
+	data := []struct {
+		inType   string
+		pkg      string
+		expected Type
+	}{
+		// Tests without package name
+		{"string", "", String},
+		{"[]byte", "", Blob},
+		{"bool", "", Bool},
+		{"int32", "", Int32},
+		{"int64", "", Int64},
+		{"float64", "", Double},
+		{"time.Time", "", Timestamp},
+		{"UUID", "", TUUID},
+		{"NullString", "", TNullString},
+		{"NullInt64", "", TNullInt64},
+		{"NullFloat64", "", TNullFloat64},
+		{"NullBool", "", TNullBool},
+
+		// Tests with package name that doesn't end with dot.
+		{"dosa.UUID", "dosa", TUUID},
+		{"dosa.NullString", "dosa", TNullString},
+		{"dosa.NullInt64", "dosa", TNullInt64},
+		{"dosa.NullFloat64", "dosa", TNullFloat64},
+		{"dosa.NullBool", "dosa", TNullBool},
+
+		// Tests with package name that ends with dot.
+		{"dosa.UUID", "dosa.", TUUID},
+		{"dosa.NullString", "dosa.", TNullString},
+		{"dosa.NullInt64", "dosa.", TNullInt64},
+		{"dosa.NullFloat64", "dosa.", TNullFloat64},
+		{"dosa.NullBool", "dosa.", TNullBool},
+
+		{"unknown", "", Invalid},
+	}
+
+	for _, tc := range data {
+		assert.Equal(t, tc.expected, stringToDosaType(tc.inType, tc.pkg),
+			fmt.Sprintf("stringToDosaType(%q, %q) != %d", tc.inType, tc.pkg, tc.expected))
 	}
 }

--- a/finder_test.go
+++ b/finder_test.go
@@ -54,8 +54,8 @@ func TestNonExistentDirectory(t *testing.T) {
 
 func TestParser(t *testing.T) {
 	entities, errs, err := FindEntities([]string{"."}, []string{})
-	assert.Equal(t, 13, len(entities), fmt.Sprintf("%s", entities))
-	assert.Equal(t, 14, len(errs), fmt.Sprintf("%v", errs))
+	assert.Equal(t, 15, len(entities), fmt.Sprintf("%s", entities))
+	assert.Equal(t, 13, len(errs), fmt.Sprintf("%v", errs))
 	assert.Nil(t, err)
 
 	for _, entity := range entities {
@@ -73,6 +73,8 @@ func TestParser(t *testing.T) {
 			e, _ = TableFromInstance(&PrimaryKeyWithDescendingRange{})
 		case "multicomponentprimarykey":
 			e, _ = TableFromInstance(&MultiComponentPrimaryKey{})
+		case "nullabletype":
+			e, _ = TableFromInstance(&NullableType{})
 		case "alltypes":
 			e, _ = TableFromInstance(&AllTypes{})
 		case "unexportedfieldtype":
@@ -91,6 +93,7 @@ func TestParser(t *testing.T) {
 			t.Errorf("entity %s not expected", entity.Name)
 			continue
 		}
+
 		assert.Equal(t, e, entity)
 	}
 }
@@ -103,8 +106,9 @@ func TestExclusion(t *testing.T) {
 }
 
 func TestFindEntitiesInOtherPkg(t *testing.T) {
-	_, warnings, err := FindEntities([]string{"testentity"}, []string{})
+	entities, warnings, err := FindEntities([]string{"testentity"}, []string{})
 	assert.NoError(t, err)
+	assert.Equal(t, 2, len(entities))
 	assert.Empty(t, warnings)
 }
 

--- a/finder_test.go
+++ b/finder_test.go
@@ -110,7 +110,7 @@ func TestExclusion(t *testing.T) {
 func TestFindEntitiesInOtherPkg(t *testing.T) {
 	entities, warnings, err := FindEntities([]string{"testentity"}, []string{})
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(entities))
+	assert.Equal(t, 4, len(entities))
 	assert.Empty(t, warnings)
 }
 
@@ -123,41 +123,43 @@ func BenchmarkFinder(b *testing.B) {
 func TestStringToDosaType(t *testing.T) {
 	data := []struct {
 		inType   string
+		pkg      string
 		expected Type
 	}{
 		// Tests without package name
-		{"string", String},
-		{"[]byte", Blob},
-		{"bool", Bool},
-		{"int32", Int32},
-		{"int64", Int64},
-		{"float64", Double},
-		{"time.Time", Timestamp},
-		{"UUID", TUUID},
-		{"NullString", TNullString},
-		{"NullInt64", TNullInt64},
-		{"NullFloat64", TNullFloat64},
-		{"NullBool", TNullBool},
+		{"string", "", String},
+		{"[]byte", "", Blob},
+		{"bool", "", Bool},
+		{"int32", "", Int32},
+		{"int64", "", Int64},
+		{"float64", "", Double},
+		{"time.Time", "", Timestamp},
+		{"UUID", "", TUUID},
+		{"NullString", "", TNullString},
+		{"NullInt64", "", TNullInt64},
+		{"NullFloat64", "", TNullFloat64},
+		{"NullBool", "", TNullBool},
 
 		// Tests with package name that doesn't end with dot.
-		{"dosa.UUID", TUUID},
-		{"dosa.NullString", TNullString},
-		{"dosa.NullInt64", TNullInt64},
-		{"dosa.NullFloat64", TNullFloat64},
-		{"dosa.NullBool", TNullBool},
+		{"dosa.UUID", "dosa", TUUID},
+		{"dosa.NullString", "dosa", TNullString},
+		{"dosa.NullInt64", "dosa", TNullInt64},
+		{"dosa.NullFloat64", "dosa", TNullFloat64},
+		{"dosa.NullBool", "dosa", TNullBool},
 
 		// Tests with package name that ends with dot.
-		{"dosa.UUID", TUUID},
-		{"dosa.NullString", TNullString},
-		{"dosa.NullInt64", TNullInt64},
-		{"dosa.NullFloat64", TNullFloat64},
-		{"dosa.NullBool", TNullBool},
+		{"dosav2.UUID", "dosav2.", TUUID},
+		{"dosav2.NullString", "dosav2.", TNullString},
+		{"dosav2.NullInt64", "dosav2.", TNullInt64},
+		{"dosav2.NullFloat64", "dosav2.", TNullFloat64},
+		{"dosav2.NullBool", "dosav2.", TNullBool},
 
-		{"unknown", Invalid},
+		{"unknown", "", Invalid},
 	}
 
 	for _, tc := range data {
-		assert.Equal(t, tc.expected, stringToDosaType(tc.inType),
-			fmt.Sprintf("stringToDosaType(%q) != %d", tc.inType, tc.expected))
+		actual := stringToDosaType(tc.inType, tc.pkg)
+		assert.Equal(t, tc.expected, actual,
+			fmt.Sprintf("stringToDosaType(%q, %q) != %d -- actual: %d", tc.inType, tc.pkg, tc.expected, actual))
 	}
 }

--- a/finder_test.go
+++ b/finder_test.go
@@ -123,42 +123,41 @@ func BenchmarkFinder(b *testing.B) {
 func TestStringToDosaType(t *testing.T) {
 	data := []struct {
 		inType   string
-		pkg      string
 		expected Type
 	}{
 		// Tests without package name
-		{"string", "", String},
-		{"[]byte", "", Blob},
-		{"bool", "", Bool},
-		{"int32", "", Int32},
-		{"int64", "", Int64},
-		{"float64", "", Double},
-		{"time.Time", "", Timestamp},
-		{"UUID", "", TUUID},
-		{"NullString", "", TNullString},
-		{"NullInt64", "", TNullInt64},
-		{"NullFloat64", "", TNullFloat64},
-		{"NullBool", "", TNullBool},
+		{"string", String},
+		{"[]byte", Blob},
+		{"bool", Bool},
+		{"int32", Int32},
+		{"int64", Int64},
+		{"float64", Double},
+		{"time.Time", Timestamp},
+		{"UUID", TUUID},
+		{"NullString", TNullString},
+		{"NullInt64", TNullInt64},
+		{"NullFloat64", TNullFloat64},
+		{"NullBool", TNullBool},
 
 		// Tests with package name that doesn't end with dot.
-		{"dosa.UUID", "dosa", TUUID},
-		{"dosa.NullString", "dosa", TNullString},
-		{"dosa.NullInt64", "dosa", TNullInt64},
-		{"dosa.NullFloat64", "dosa", TNullFloat64},
-		{"dosa.NullBool", "dosa", TNullBool},
+		{"dosa.UUID", TUUID},
+		{"dosa.NullString", TNullString},
+		{"dosa.NullInt64", TNullInt64},
+		{"dosa.NullFloat64", TNullFloat64},
+		{"dosa.NullBool", TNullBool},
 
 		// Tests with package name that ends with dot.
-		{"dosa.UUID", "dosa.", TUUID},
-		{"dosa.NullString", "dosa.", TNullString},
-		{"dosa.NullInt64", "dosa.", TNullInt64},
-		{"dosa.NullFloat64", "dosa.", TNullFloat64},
-		{"dosa.NullBool", "dosa.", TNullBool},
+		{"dosa.UUID", TUUID},
+		{"dosa.NullString", TNullString},
+		{"dosa.NullInt64", TNullInt64},
+		{"dosa.NullFloat64", TNullFloat64},
+		{"dosa.NullBool", TNullBool},
 
-		{"unknown", "", Invalid},
+		{"unknown", Invalid},
 	}
 
 	for _, tc := range data {
-		assert.Equal(t, tc.expected, stringToDosaType(tc.inType, tc.pkg),
-			fmt.Sprintf("stringToDosaType(%q, %q) != %d", tc.inType, tc.pkg, tc.expected))
+		assert.Equal(t, tc.expected, stringToDosaType(tc.inType),
+			fmt.Sprintf("stringToDosaType(%q) != %d", tc.inType, tc.expected))
 	}
 }

--- a/finder_test.go
+++ b/finder_test.go
@@ -55,7 +55,7 @@ func TestNonExistentDirectory(t *testing.T) {
 func TestParser(t *testing.T) {
 	entities, errs, err := FindEntities([]string{"."}, []string{})
 	assert.Equal(t, 15, len(entities), fmt.Sprintf("%s", entities))
-	assert.Equal(t, 13, len(errs), fmt.Sprintf("%v", errs))
+	assert.Equal(t, 17, len(errs), fmt.Sprintf("%v", errs))
 	assert.Nil(t, err)
 
 	for _, entity := range entities {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -111,7 +111,7 @@ func TestRegistrar_FindAll(t *testing.T) {
 	assert.NotNil(t, reg)
 	res, err = reg.FindAll()
 	assert.NoError(t, err)
-	assert.Equal(t, len(res), 1)
+	assert.Equal(t, len(res), 2)
 
 	// found many
 	cfg.EntityPaths = []string{".", "../testentity"}
@@ -120,7 +120,7 @@ func TestRegistrar_FindAll(t *testing.T) {
 	assert.NotNil(t, reg)
 	res, err = reg.FindAll()
 	assert.NoError(t, err)
-	assert.Equal(t, len(res), 3)
+	assert.Equal(t, len(res), 4)
 }
 
 func TestNewRegistrar(t *testing.T) {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -104,23 +104,23 @@ func TestRegistrar_FindAll(t *testing.T) {
 	res, err := reg.FindAll()
 	assert.Error(t, err)
 
-	// found 1
+	// found 4
 	cfg.EntityPaths = []string{"../testentity"}
 	reg, err = registry.NewRegistrar(cfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, reg)
 	res, err = reg.FindAll()
 	assert.NoError(t, err)
-	assert.Equal(t, len(res), 2)
+	assert.Equal(t, len(res), 4)
 
-	// found many
+	// found all i.e. 6 (4 under testentity, two in this file)
 	cfg.EntityPaths = []string{".", "../testentity"}
 	reg, err = registry.NewRegistrar(cfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, reg)
 	res, err = reg.FindAll()
 	assert.NoError(t, err)
-	assert.Equal(t, len(res), 4)
+	assert.Equal(t, len(res), 6)
 }
 
 func TestNewRegistrar(t *testing.T) {

--- a/scan_test.go
+++ b/scan_test.go
@@ -30,16 +30,20 @@ import (
 	"github.com/uber-go/dosa"
 )
 
-type AllTypes struct {
-	dosa.Entity `dosa:"primaryKey=BoolType"`
-	BoolType    bool
-	Int32Type   int32
-	Int64Type   int64
-	DoubleType  float64
-	StringType  string
-	BlobType    []byte
-	TimeType    time.Time
-	UUIDType    dosa.UUID
+type AllTypesScanTestEntity struct {
+	dosa.Entity     `dosa:"primaryKey=BoolType"`
+	BoolType        bool
+	Int32Type       int32
+	Int64Type       int64
+	DoubleType      float64
+	StringType      string
+	BlobType        []byte
+	TimeType        time.Time
+	UUIDType        dosa.UUID
+	NullStringType  dosa.NullString
+	NullInt64Type   dosa.NullInt64
+	NullFloat64Type dosa.NullFloat64
+	NullBoolType    dosa.NullBool
 }
 
 func TestNewScanOp(t *testing.T) {
@@ -61,31 +65,31 @@ var ScanTestCases = []struct {
 }{
 	{
 		descript: "empty scanop, valid",
-		sop:      dosa.NewScanOp(&AllTypes{}),
+		sop:      dosa.NewScanOp(&AllTypesScanTestEntity{}),
 		stringer: "ScanOp",
 	},
 	{
 		descript: "empty with limit",
-		sop:      dosa.NewScanOp(&AllTypes{}).Limit(10),
+		sop:      dosa.NewScanOp(&AllTypesScanTestEntity{}).Limit(10),
 		stringer: "ScanOp limit 10",
 	},
 	{
 		descript: "empty with token",
-		sop:      dosa.NewScanOp(&AllTypes{}).Offset("toketoketoke"),
+		sop:      dosa.NewScanOp(&AllTypesScanTestEntity{}).Offset("toketoketoke"),
 		stringer: "ScanOp token \"toketoketoke\"",
 	},
 	{
 		descript: "with valid field list",
-		sop:      dosa.NewScanOp(&AllTypes{}).Fields([]string{"StringType"}),
+		sop:      dosa.NewScanOp(&AllTypesScanTestEntity{}).Fields([]string{"StringType"}),
 		stringer: "ScanOp",
 	},
 }
 
 func TestScanOpMatcher(t *testing.T) {
-	scanOp0 := dosa.NewScanOp(&AllTypes{}).Limit(1)
-	scanOp1 := dosa.NewScanOp(&AllTypes{}).Limit(1)
-	scanOp2 := dosa.NewScanOp(&AllTypes{}).Limit(1).Offset("token1")
-	scanOp3 := dosa.NewScanOp(&AllTypes{}).Limit(1).Fields([]string{"BoolType", "TimeType"})
+	scanOp0 := dosa.NewScanOp(&AllTypesScanTestEntity{}).Limit(1)
+	scanOp1 := dosa.NewScanOp(&AllTypesScanTestEntity{}).Limit(1)
+	scanOp2 := dosa.NewScanOp(&AllTypesScanTestEntity{}).Limit(1).Offset("token1")
+	scanOp3 := dosa.NewScanOp(&AllTypesScanTestEntity{}).Limit(1).Fields([]string{"BoolType", "TimeType"})
 	scanOp4 := dosa.NewScanOp(&dosa.Entity{}).Limit(1)
 
 	matcher := dosa.EqScanOp(scanOp0)

--- a/schema/avro/avro.go
+++ b/schema/avro/avro.go
@@ -39,14 +39,18 @@ const (
 
 // map from dosa type to avro type
 var avroTypes = map[dosa.Type]gv.Schema{
-	dosa.String:    &gv.StringSchema{},
-	dosa.Blob:      &gv.BytesSchema{},
-	dosa.Bool:      &gv.BooleanSchema{},
-	dosa.Double:    &gv.DoubleSchema{},
-	dosa.Int32:     &gv.IntSchema{},
-	dosa.Int64:     &gv.LongSchema{},
-	dosa.Timestamp: &gv.LongSchema{},
-	dosa.TUUID:     &gv.StringSchema{},
+	dosa.String:       &gv.StringSchema{},
+	dosa.Blob:         &gv.BytesSchema{},
+	dosa.Bool:         &gv.BooleanSchema{},
+	dosa.Double:       &gv.DoubleSchema{},
+	dosa.Int32:        &gv.IntSchema{},
+	dosa.Int64:        &gv.LongSchema{},
+	dosa.Timestamp:    &gv.LongSchema{},
+	dosa.TUUID:        &gv.StringSchema{},
+	dosa.TNullString:  &gv.StringSchema{},
+	dosa.TNullInt64:   &gv.LongSchema{},
+	dosa.TNullFloat64: &gv.DoubleSchema{},
+	dosa.TNullBool:    &gv.BooleanSchema{},
 }
 
 // Record implements Schema and represents Avro record type.

--- a/testentity/named_import_testentity.go
+++ b/testentity/named_import_testentity.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package testentity
+
+import (
+	"time"
+
+	// Using a named import is the key change in this file. This is
+	// used to test the entity parser against named dosa imports.
+	dosav2 "github.com/uber-go/dosa"
+)
+
+// TestNamedImportEntity uses common key types and all types in value fields.
+type TestNamedImportEntity struct {
+	dosav2.Entity `dosa:"name=awesome_test_entity, primaryKey=(UUIDKey, StrKey ASC, Int64Key DESC)"`
+	UUIDKey       dosav2.UUID `dosa:"name=an_uuid_key"`
+	StrKey        string
+	Int64Key      int64
+	UUIDV         dosav2.UUID
+	StrV          string
+	Int64V        int64 `dosa:"name=an_int64_value"`
+	Int32V        int32
+	DoubleV       float64
+	BoolV         bool
+	BlobV         []byte
+	TSV           time.Time
+}
+
+// TestNullableNamedImportEntity uses nullable fields.
+type TestNullableNamedImportEntity struct {
+	dosav2.Entity   `dosa:"primaryKey=BoolType"`
+	BoolType        bool
+	NullStringType  dosav2.NullString
+	NullInt64Type   dosav2.NullInt64
+	NullFloat64Type dosav2.NullFloat64
+	NullBoolType    dosav2.NullBool
+}

--- a/testentity/named_import_testentity.go
+++ b/testentity/named_import_testentity.go
@@ -30,7 +30,7 @@ import (
 
 // TestNamedImportEntity uses common key types and all types in value fields.
 type TestNamedImportEntity struct {
-	dosav2.Entity `dosa:"name=awesome_test_entity, primaryKey=(UUIDKey, StrKey ASC, Int64Key DESC)"`
+	dosav2.Entity `dosa:"name=named_import_entity, primaryKey=(UUIDKey, StrKey ASC, Int64Key DESC)"`
 	UUIDKey       dosav2.UUID `dosa:"name=an_uuid_key"`
 	StrKey        string
 	Int64Key      int64

--- a/testentity/testentity.go
+++ b/testentity/testentity.go
@@ -41,3 +41,13 @@ type TestEntity struct {
 	BlobV       []byte
 	TSV         time.Time
 }
+
+// TestNullableEntity uses nullable fields.
+type TestNullableEntity struct {
+	dosa.Entity     `dosa:"primaryKey=BoolType"`
+	BoolType        bool
+	NullStringType  dosa.NullString
+	NullInt64Type   dosa.NullInt64
+	NullFloat64Type dosa.NullFloat64
+	NullBoolType    dosa.NullBool
+}

--- a/type.go
+++ b/type.go
@@ -130,3 +130,13 @@ func FromString(s string) Type {
 		return Invalid
 	}
 }
+
+func isNullableType(t Type) bool {
+	switch t {
+	case Invalid, TNullString, TNullFloat64, TNullInt64, TNullBool:
+		return true
+	default:
+		return false
+	}
+}
+

--- a/type.go
+++ b/type.go
@@ -139,4 +139,3 @@ func isNullableType(t Type) bool {
 		return false
 	}
 }
-

--- a/type.go
+++ b/type.go
@@ -57,6 +57,18 @@ const (
 
 	// Bool is a bool type
 	Bool
+
+	// TNullString represents an optional string value
+	TNullString
+
+	// TNullInt64 represents an optional int64 value
+	TNullInt64
+
+	// TNullFloat64 represents an optional float64 value
+	TNullFloat64
+
+	// TNullBool represents an optional bool value
+	TNullBool
 )
 
 // UUID stores a string format of uuid.
@@ -106,6 +118,14 @@ func FromString(s string) Type {
 		return Timestamp
 	case Bool.String():
 		return Bool
+	case TNullString.String():
+		return TNullString
+	case TNullInt64.String():
+		return TNullInt64
+	case TNullFloat64.String():
+		return TNullFloat64
+	case TNullBool.String():
+		return TNullBool
 	default:
 		return Invalid
 	}

--- a/type.go
+++ b/type.go
@@ -131,7 +131,7 @@ func FromString(s string) Type {
 	}
 }
 
-func isValidPrimaryKeyType(t Type) bool {
+func isInvalidPrimaryKeyType(t Type) bool {
 	switch t {
 	case Invalid, TNullString, TNullFloat64, TNullInt64, TNullBool:
 		return true

--- a/type.go
+++ b/type.go
@@ -131,7 +131,7 @@ func FromString(s string) Type {
 	}
 }
 
-func isNullableType(t Type) bool {
+func isValidPrimaryKeyType(t Type) bool {
 	switch t {
 	case Invalid, TNullString, TNullFloat64, TNullInt64, TNullBool:
 		return true

--- a/type_test.go
+++ b/type_test.go
@@ -179,6 +179,6 @@ func TestIsNullableType(t *testing.T) {
 		},
 	}
 	for _, tc := range tt {
-		assert.Equal(t, isNullableType(tc.input), tc.expected)
+		assert.Equal(t, isValidPrimaryKeyType(tc.input), tc.expected)
 	}
 }

--- a/type_test.go
+++ b/type_test.go
@@ -119,3 +119,66 @@ func TestFromString(t *testing.T) {
 		assert.Equal(t, FromString(tc.input), tc.expected)
 	}
 }
+
+func TestIsNullableType(t *testing.T) {
+	tt := []struct {
+		input Type
+		expected bool
+	}{
+		{
+			input:    TUUID,
+			expected: false,
+		},
+		{
+			input:    String,
+			expected: false,
+		},
+		{
+			input:    Int32,
+			expected: false,
+		},
+		{
+			input:    Int64,
+			expected: false,
+		},
+		{
+			input:    Double,
+			expected: false,
+		},
+		{
+			input:    Blob,
+			expected: false,
+		},
+		{
+			input:    Timestamp,
+			expected: false,
+		},
+		{
+			input:    Bool,
+			expected: false,
+		},
+		{
+			input:    TNullString,
+			expected: true,
+		},
+		{
+			input:    TNullInt64,
+			expected: true,
+		},
+		{
+			input:    TNullFloat64,
+			expected: true,
+		},
+		{
+			input:    TNullBool,
+			expected: true,
+		},
+		{
+			input:    Invalid,
+			expected: true,		// We treat Invalid as nullable type.
+		},
+	}
+	for _, tc := range tt {
+		assert.Equal(t, isNullableType(tc.input), tc.expected)
+	}
+}

--- a/type_test.go
+++ b/type_test.go
@@ -94,6 +94,22 @@ func TestFromString(t *testing.T) {
 			expected: Bool,
 		},
 		{
+			input:    TNullString.String(),
+			expected: TNullString,
+		},
+		{
+			input:    TNullInt64.String(),
+			expected: TNullInt64,
+		},
+		{
+			input:    TNullFloat64.String(),
+			expected: TNullFloat64,
+		},
+		{
+			input:    TNullBool.String(),
+			expected: TNullBool,
+		},
+		{
 			input:    "invalid",
 			expected: Invalid,
 		},

--- a/type_test.go
+++ b/type_test.go
@@ -122,7 +122,7 @@ func TestFromString(t *testing.T) {
 
 func TestIsNullableType(t *testing.T) {
 	tt := []struct {
-		input Type
+		input    Type
 		expected bool
 	}{
 		{
@@ -175,7 +175,7 @@ func TestIsNullableType(t *testing.T) {
 		},
 		{
 			input:    Invalid,
-			expected: true,		// We treat Invalid as nullable type.
+			expected: true, // We treat Invalid as nullable type.
 		},
 	}
 	for _, tc := range tt {

--- a/type_test.go
+++ b/type_test.go
@@ -179,6 +179,6 @@ func TestIsNullableType(t *testing.T) {
 		},
 	}
 	for _, tc := range tt {
-		assert.Equal(t, isValidPrimaryKeyType(tc.input), tc.expected)
+		assert.Equal(t, isInvalidPrimaryKeyType(tc.input), tc.expected)
 	}
 }


### PR DESCRIPTION
This change adds basic 4 nullable types to entity parser (JIRA-926/929). It includes a few bug fixes to existing code as well. This change also covers parts of the request path. Response path along with remaining Yarpc Connector changes will be covered in following CRs. 
