### PR TITLE
add RemoveRange to Connector interface

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -111,6 +111,8 @@ type Connector interface {
 	MultiUpsert(ctx context.Context, ei *EntityInfo, multiValues []map[string]FieldValue) (result []error, err error)
 	// Remove deletes a row
 	Remove(ctx context.Context, ei *EntityInfo, keys map[string]FieldValue) error
+	// RemoveRange removes all entities in a particular range
+	RemoveRange(ctx context.Context, ei *EntityInfo, columnConditions map[string][]*Condition) error
 	// MultiRemove removes multiple rows
 	MultiRemove(ctx context.Context, ei *EntityInfo, multiKeys []map[string]FieldValue) (result []error, err error)
 	// Range does a range scan using a set of conditions.

--- a/connectors/base/base.go
+++ b/connectors/base/base.go
@@ -95,6 +95,14 @@ func (c *Connector) Remove(ctx context.Context, ei *dosa.EntityInfo, values map[
 	return c.Next.Remove(ctx, ei, values)
 }
 
+// RemoveRange calls Next.
+func (c *Connector) RemoveRange(ctx context.Context, ei *dosa.EntityInfo, columnConditions map[string][]*dosa.Condition) error {
+	if c.Next == nil {
+		return ErrNoMoreConnector{}
+	}
+	return c.Next.RemoveRange(ctx, ei, columnConditions)
+}
+
 // MultiRemove calls Next
 func (c *Connector) MultiRemove(ctx context.Context, ei *dosa.EntityInfo, multiValues []map[string]dosa.FieldValue) ([]error, error) {
 	if c.Next == nil {

--- a/connectors/base/base_test.go
+++ b/connectors/base/base_test.go
@@ -102,6 +102,15 @@ func TestBase_Remove(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestBase_RemoveRange(t *testing.T) {
+	conditions := make(map[string][]*dosa.Condition)
+	err := bc.RemoveRange(ctx, testInfo, conditions)
+	assert.Error(t, err)
+
+	err = bcWNext.RemoveRange(ctx, testInfo, conditions)
+	assert.NoError(t, err)
+}
+
 func TestBase_MultiRemove(t *testing.T) {
 	_, err := bc.MultiRemove(ctx, testInfo, testMultiValues)
 	assert.Error(t, err)

--- a/mocks/connector.go
+++ b/mocks/connector.go
@@ -182,6 +182,17 @@ func (_mr *_MockConnectorRecorder) Remove(arg0, arg1, arg2 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Remove", arg0, arg1, arg2)
 }
 
+// RemoveRange is a mock implementation of MockConnector.RemoveRange
+func (_m *MockConnector) RemoveRange(_param0 context.Context, _param1 *dosa.EntityInfo, _param2 map[string][]*dosa.Condition) error {
+	ret := _m.ctrl.Call(_m, "RemoveRange", _param0, _param1, _param2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockConnectorRecorder) RemoveRange(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveRange", arg0, arg1, arg2)
+}
+
 // Scan is a mock implementation of MockConnector.Scan
 func (_m *MockConnector) Scan(_param0 context.Context, _param1 *dosa.EntityInfo, _param2 []string, _param3 string, _param4 int) ([]map[string]dosa.FieldValue, string, error) {
 	ret := _m.ctrl.Call(_m, "Scan", _param0, _param1, _param2, _param3, _param4)


### PR DESCRIPTION
We've now got remove range in all of our connectors*, so let's add it to the connector interface.


*actually, we're still missing it in the base connector, but we'll add that here too.