### PR TITLE
Allow entities to be provided explicitly to dosaclient.New

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -31,12 +31,10 @@ import (
 
 // New creates a new DOSA client from the configuration provided. Depending
 // on the configuration, this method will create the appropriate connector
-// and will try to find DOSA entities to register before returning an
-// initialized client or an error. See the config package for defaults.
-func New(cfg *config.Config) (dosa.Client, error) {
-	// create registry from config, by default this will search ./entities/dosa
-	// for types that implement dosa.DomainObject and have valid primary key.
-	reg, err := registry.NewRegistrar(cfg)
+// and will register the entities provided before returning an initialized
+// client or an error. See the config package for defaults.
+func New(cfg *config.Config, entities ...dosa.DomainObject) (dosa.Client, error) {
+	reg, err := registry.NewRegistrar(cfg, entities...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not register DOSA entities in %s", cfg.EntityPaths)
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/uber-go/dosa/connectors/devnull"
 	_ "github.com/uber-go/dosa/connectors/memory"
 	_ "github.com/uber-go/dosa/connectors/random"
+	"github.com/uber-go/dosa/testentity"
 )
 
 func TestNew(t *testing.T) {
@@ -84,6 +85,11 @@ func TestNew(t *testing.T) {
 	randomCfg.Connector["name"] = "random"
 	randomCfg.EntityPaths = entityPathsValid
 	c, err = dosaclient.New(&randomCfg)
+	assert.NotNil(t, c)
+	assert.NoError(t, err)
+
+	// explicit entity registration using memory connector
+	c, err = dosaclient.New(&memoryCfg, &testentity.TestEntity{})
 	assert.NotNil(t, c)
 	assert.NoError(t, err)
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -70,7 +70,16 @@ func (r *registrar) FindAll() ([]*dosa.RegisteredEntity, error) {
 }
 
 // NewRegistrar returns a new Registrar for the configuration provided.
-func NewRegistrar(cfg *config.Config) (dosa.Registrar, error) {
+func NewRegistrar(cfg *config.Config, entities ...dosa.DomainObject) (dosa.Registrar, error) {
+	// when entities are provided explicitly, discovery isn't necessary. In
+	// fact, the whole "auto-discovery" feature should only be used as a
+	// convenience for the CLI -- it's fundamentally problematic for
+	// environments where the source is not distributed alongside the binary
+	// where there is nothing to be discovered.
+	if len(entities) > 0 {
+		return dosa.NewRegistrar(cfg.Scope, cfg.NamePrefix, entities...)
+	}
+
 	idx := make(map[dosa.FQN]*dosa.RegisteredEntity)
 	baseFQN, err := dosa.ToFQN(cfg.NamePrefix)
 	// invalid prefix/FQN

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -125,11 +125,19 @@ func TestRegistrar_FindAll(t *testing.T) {
 
 func TestNewRegistrar(t *testing.T) {
 	cases := []struct {
-		scope  string
-		prefix string
-		paths  []string
-		err    string
+		scope    string
+		prefix   string
+		entities []dosa.DomainObject
+		paths    []string
+		err      string
 	}{
+		// explicit entity registration
+		{
+			entities: []dosa.DomainObject{
+				&TestEntity1{},
+				&TestEntity2{},
+			},
+		},
 		// invalid prefix
 		{
 			prefix: "--",
@@ -160,7 +168,7 @@ func TestNewRegistrar(t *testing.T) {
 			NamePrefix:  c.prefix,
 			EntityPaths: c.paths,
 		}
-		reg, err := registry.NewRegistrar(cfg)
+		reg, err := registry.NewRegistrar(cfg, c.entities...)
 		if c.err != "" {
 			assert.Contains(t, err.Error(), c.err)
 			continue


### PR DESCRIPTION
This corrects an oversight in the design of the `dosaclient` interface which was the assumption that entities could be "auto-discovered" -- this is not feasible for environments where only a binary is distributed and thus there is nothing to be "discovered". This maintains backwards compatibility by allowing the associated client and registry constructors to optionally take a slice of entities that will cause entity discovery to be subverted.