### PR TITLE
Add support for memory connector Range() tokens

### DIFF
--- a/connectors/memory/memory.go
+++ b/connectors/memory/memory.go
@@ -499,11 +499,6 @@ func (c *Connector) Shutdown() error {
 	return nil
 }
 
-// Name returns the name of the connector
-func Name() string {
-	return name
-}
-
 // NewConnector creates a new in-memory connector
 func NewConnector() *Connector {
 	c := Connector{}

--- a/connectors/memory/memory_test.go
+++ b/connectors/memory/memory_test.go
@@ -785,21 +785,6 @@ func TestPanics(t *testing.T) {
 	})
 }
 
-// createTestData populates some test data. The keyGenFunc can either return a constant,
-// which gives you a single partition of data, or some function of the current offset, which
-// will scatter the data across different partition keys
-func createTestData(t *testing.T, sut *Connector, keyGenFunc func(int) string, idcount int) {
-	// insert a bunch of values with V1 timestamps as clustering keys
-	for x := 0; x < idcount; x++ {
-		err := sut.Upsert(context.TODO(), clusteredEi, map[string]dosa.FieldValue{
-			"f1": dosa.FieldValue(keyGenFunc(x)),
-			"c1": dosa.FieldValue(int64(1)),
-			"c6": dosa.FieldValue(int32(x)),
-			"c7": dosa.FieldValue(dosa.UUID(uuid.NewV1().String()))})
-		assert.NoError(t, err)
-	}
-}
-
 func TestRangePager(t *testing.T) {
 	sut := NewConnector()
 	idcount := 5
@@ -873,4 +858,19 @@ func TestEncoderPanic(t *testing.T) {
 			"oops": func() {},
 		})
 	})
+}
+
+// createTestData populates some test data. The keyGenFunc can either return a constant,
+// which gives you a single partition of data, or some function of the current offset, which
+// will scatter the data across different partition keys
+func createTestData(t *testing.T, sut *Connector, keyGenFunc func(int) string, idcount int) {
+	// insert a bunch of values with V1 timestamps as clustering keys
+	for x := 0; x < idcount; x++ {
+		err := sut.Upsert(context.TODO(), clusteredEi, map[string]dosa.FieldValue{
+			"f1": dosa.FieldValue(keyGenFunc(x)),
+			"c1": dosa.FieldValue(int64(1)),
+			"c6": dosa.FieldValue(int32(x)),
+			"c7": dosa.FieldValue(dosa.UUID(uuid.NewV1().String()))})
+		assert.NoError(t, err)
+	}
 }


### PR DESCRIPTION
This implements continuation tokens for the Range() operator in the
memory connector.  Just before returning from Range(), if the length
of the return value is longer than requested, we encode the data
in the last value returned to the user.  The encoding is a base64
encoded gob.

When a token is supplied on a future call to Range(), we still find
all the rows, and then decode the token, and look for that value
in the result set.  If we find it, then we just start at the next
value. If it's not there, that's okay too; we just start at the
next value in the set. The latter can only happen when the specific
value in the token has been deleted.