### PR TITLE
[easy] Update RangeOp.Limit docstring

### DIFF
--- a/range.go
+++ b/range.go
@@ -111,8 +111,8 @@ func (r *RangeOp) Fields(fieldsToRead []string) *RangeOp {
 	return r
 }
 
-// Limit sets the number of rows returned per call. If not set, a default
-// value would be applied
+// Limit sets the number of rows returned per call. A limit must be provided
+// otherwise an error will be returned.
 func (r *RangeOp) Limit(n int) *RangeOp {
 	r.sop.limit = n
 	return r

--- a/range.go
+++ b/range.go
@@ -111,8 +111,9 @@ func (r *RangeOp) Fields(fieldsToRead []string) *RangeOp {
 	return r
 }
 
-// Limit sets the number of rows returned per call. A limit must be provided
-// otherwise an error will be returned.
+// Limit sets the number of rows returned per call. A limit must be provided.
+// If a limit is not provided, an error will be generated at query
+// execution-time.
 func (r *RangeOp) Limit(n int) *RangeOp {
 	r.sop.limit = n
 	return r


### PR DESCRIPTION
Fixes [DOSA-1049](https://jira.uberinternal.com/browse/DOSA-1049) - Docstring for RangeOp.Limit misrepresents default behavior.