### PR TITLE
glide cleanup

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,14 +1,32 @@
-hash: 6d27efe914b9b5853f9f4f96d1cbc6eaab26d921c201c537306ac6d18f5d7871
-updated: 2017-06-07T15:38:52.288658056-07:00
+hash: da4961ee3d7589c108093b1619064cfd760e48ad248d8c96da03b1dd33e4f09a
+updated: 2017-06-21T11:47:23.052061296-07:00
 imports:
+- name: github.com/beorn7/perks
+  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  subpackages:
+  - quantile
 - name: github.com/elodina/go-avro
   version: 0c8185d9a3ba82aeac98db3313a268a5b6df99b5
+- name: github.com/facebookgo/clock
+  version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
+- name: github.com/gogo/protobuf
+  version: 100ba4e885062801d56799d78530b73b178a78f3
+  subpackages:
+  - proto
 - name: github.com/golang/mock
-  version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
+  version: b2105fd81bd2667d699d23c10d5a299bfe859d56
   subpackages:
   - gomock
+- name: github.com/golang/protobuf
+  version: 1fb8fd32a09087bcd727225167edd31e1b9ceb24
+  subpackages:
+  - proto
 - name: github.com/jessevdk/go-flags
-  version: 5695738f733662da3e9afc2283bba6f3c879002d
+  version: 48cf8722c3375517aba351d1f7577c40663a4407
+- name: github.com/matttproud/golang_protobuf_extensions
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  subpackages:
+  - pbutil
 - name: github.com/opentracing/opentracing-go
   version: 1949ddbfd147afd4d964a9f00b24eb291e0e7c38
   subpackages:
@@ -16,19 +34,38 @@ imports:
   - log
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
+- name: github.com/prometheus/client_golang
+  version: c5b7fccd204277076155f10851dad72b76a49317
+  subpackages:
+  - prometheus
+  - prometheus/promhttp
+- name: github.com/prometheus/client_model
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
+  subpackages:
+  - go
+- name: github.com/prometheus/common
+  version: 0866df4b85a18d652b6965be022d007cdf076822
+  subpackages:
+  - expfmt
+  - internal/bitbucket.org/ww/goautoneg
+  - model
+- name: github.com/prometheus/procfs
+  version: 822d4a1f8edcbcbc71e8d1fd6527b12331a6d0ad
+  subpackages:
+  - xfs
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
-- name: github.com/stretchr/testify
-  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
-  subpackages:
-  - assert
-  - mock
 - name: github.com/uber-go/atomic
-  version: 908889c45e73bedd558e99819aea3be3503fc581
-- name: github.com/uber/dosa-idl
-  version: a887a8e79251bed4bffeaf52a90905b0fb14adbf
+  version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
+- name: github.com/uber-go/mapdecode
+  version: 2d8ecd5e64c88634bd7dfcbc9fd2a9e813830e8d
   subpackages:
-  - .gen
+  - internal/mapstructure
+- name: github.com/uber-go/tally
+  version: e9b601813b0be4771b1b3995390567b67ab2b3fc
+- name: github.com/uber/dosa-idl
+  version: 741c2b509f47fbd398358eb862a5f2187b1c59f2
+  subpackages:
   - .gen/dosa
   - .gen/dosa/dosaclient
   - .gen/dosa/dosatest
@@ -41,12 +78,10 @@ imports:
   - tos
   - trand
   - typed
-- name: github.com/yarpc/yarpc-go
-  version: 6ae533f0810337028ef055b690360e050aa13219
-- name: github.com/yookoala/realpath
-  version: c416d99ab5ed256fa30c1f3bab73152deb59bb69
 - name: go.uber.org/atomic
   version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
+- name: go.uber.org/multierr
+  version: ef109dc7f883f3a99db2d89edc701c25cac40571
 - name: go.uber.org/thriftrw
   version: dde90c2a40f45fb2b6361d13c1b4bf09465401c0
   subpackages:
@@ -59,7 +94,7 @@ imports:
   - version
   - wire
 - name: go.uber.org/yarpc
-  version: 6ae533f0810337028ef055b690360e050aa13219
+  version: 25be6398200bcad9f7194ae09ba79d9f20289412
   subpackages:
   - api/encoding
   - api/middleware
@@ -69,14 +104,20 @@ imports:
   - encoding/thrift
   - encoding/thrift/internal
   - internal
+  - internal/buffer
   - internal/clientconfig
   - internal/encoding
   - internal/errors
+  - internal/humanize
   - internal/inboundmiddleware
+  - internal/interpolate
   - internal/introspection
   - internal/iopool
   - internal/net
+  - internal/observability
   - internal/outboundmiddleware
+  - internal/pally
+  - internal/procedure
   - internal/request
   - internal/sync
   - peer
@@ -84,16 +125,28 @@ imports:
   - transport/http
   - transport/tchannel
   - transport/tchannel/internal
+  - x/config
+- name: go.uber.org/zap
+  version: 9cabc84638b70e564c3dab2766efcb1ded2aac9f
+  subpackages:
+  - buffer
+  - internal/bufferpool
+  - internal/color
+  - internal/exit
+  - internal/multierror
+  - zapcore
 - name: golang.org/x/net
-  version: 59a0b19b5533c7977ddeb86b017bf507ed407b12
+  version: 057a25b06247e0c51ba15d8ae475feb2fcb72164
+  repo: https://github.com/golang/net
   subpackages:
   - bpf
   - context
-  - context/ctxhttp
   - internal/iana
   - internal/socket
   - ipv4
   - ipv6
+- name: gopkg.in/yaml.v2
+  version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
 testImports:
 - name: github.com/anmitsu/go-shlex
   version: 648efa622239a2f6ff949fed78ee37b48d499ba4
@@ -130,12 +183,18 @@ testImports:
   subpackages:
   - difflib
 - name: github.com/russross/blackfriday
-  version: e7910a813fbd94acce2680899175fa106b7b1787
+  version: 70c446a327c4e69c0f661dc092d9729c3af7472c
 - name: github.com/sectioneight/md-to-godoc
   version: 79157ff08f1acd5c5b1d13d71c0adb7908dbb8a2
 - name: github.com/shurcooL/sanitized_anchor_name
   version: 541ff5ee47f1dddf6a5281af78307d921524bcb5
+- name: github.com/stretchr/testify
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  subpackages:
+  - assert
+- name: github.com/yookoala/realpath
+  version: c416d99ab5ed256fa30c1f3bab73152deb59bb69
 - name: golang.org/x/tools
-  version: 851770f01f04a0a480149de08a871c0378bc3fed
+  version: cd6e398dae38fb8b0b57f221b13c4b75c0a53fb9
   subpackages:
   - cover

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,32 +1,31 @@
 package: github.com/uber-go/dosa
 import:
+- package: github.com/elodina/go-avro
+- package: github.com/golang/mock
+  subpackages:
+  - gomock
+- package: github.com/jessevdk/go-flags
+  version: ^1.2.0
 - package: github.com/pkg/errors
   version: ^0.8.0
 - package: github.com/satori/go.uuid
   version: ^1.1.0
-- package: github.com/elodina/go-avro
 - package: github.com/uber/dosa-idl
   subpackages:
-  - .gen
+  - .gen/dosa
+  - .gen/dosa/dosaclient
+- package: go.uber.org/yarpc
+  version: ^1.7.1
+  subpackages:
+  - api/transport
+  - transport/http
+  - transport/tchannel
+testImport:
+- package: github.com/yookoala/realpath
 - package: github.com/stretchr/testify
   version: ^1.1.4
   subpackages:
   - assert
-  - mock
-- package: github.com/golang/mock
-  subpackages:
-  - gomock
-- package: github.com/yookoala/realpath
-- package: github.com/jessevdk/go-flags
-
-# github.com/yarpc/yarpc-go and go.uber.org/yarpc are the same thing. Since we _need_ to pin yarpc-go
-# (we directly depend on it), we also pin go.uber.org/yarpc since some of our other dependencies use it.
-# These version pins should always be the same.
-- package: github.com/yarpc/yarpc-go
-  version: ~1.7.1
-- package: go.uber.org/yarpc
-  version: ~1.7.1
-testImport:
 - package: golang.org/x/tools
   subpackages:
   - cover


### PR DESCRIPTION
Our glide.yaml file needed some love. I've implemented the following changes:

- the go_flags package now tracks a semantic version
- several packages have been moved to testImport since they're not actually needed to compile any of our real code
- our yarpc dependencies have been cleaned up as well. We actually specify which subpackages we need, change the semver to ^1.7.1 and get rid of the reference to github.com/uber-go/yarpc which isn't actually used anywhere in our code.