### PR TITLE
Fix the bug that finder can't find embedded dosa.Index field

### DIFF
--- a/entity_parser_index_test.go
+++ b/entity_parser_index_test.go
@@ -46,7 +46,7 @@ func TestSingleIndexNoParen(t *testing.T) {
 
 type MultipleIndexes struct {
 	Entity       `dosa:"primaryKey=PrimaryKey"`
-	SearchByData Index `dosa:"key=Data"`
+	Index        `dosa:"key=Data, name=SearchByData"`
 	SearchByDate Index `dosa:"key=Date"`
 	PrimaryKey   int64
 	Data         string

--- a/finder.go
+++ b/finder.go
@@ -247,6 +247,19 @@ func tableFromStructType(structName string, structType *ast.StructType, packageP
 					t.FieldToCol[name] = cd.Name
 				}
 			}
+
+			if len(field.Names) == 0 {
+				if kind == packagePrefix+"."+indexName || (packagePrefix == "" && kind == indexName) {
+					indexName, indexKey, err := parseIndexTag("", dosaTag)
+					if err != nil {
+						return nil, err
+					}
+					if _, exist := t.Indexes[indexName]; exist {
+						return nil, errors.Errorf("index name is duplicated: %s", indexName)
+					}
+					t.Indexes[indexName] = &IndexDefinition{Key: indexKey}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Bug:
dosa cli can't detect embedded index field

```
type MultipleIndexes struct {
	Entity       `dosa:"primaryKey=PrimaryKey"`
	Index        `dosa:"key=Data, name=SearchByData"`
	SearchByDate Index `dosa:"key=Date"`
	PrimaryKey   int64
	Data         string
	Date         time.Time
}
```