### PR TITLE
Ensure Registered Entities are created with Index information

### DIFF
--- a/connectors/memory/memory_test.go
+++ b/connectors/memory/memory_test.go
@@ -540,6 +540,24 @@ func TestConnector_Range(t *testing.T) {
 	}, dosa.All(), "", 200)
 	assert.NoError(t, err)
 	assert.Empty(t, data)
+
+	// Test Ranging on an Index
+
+	// Get "1" partition
+	data, token, err = sut.Range(context.TODO(), clusteredEi, map[string][]*dosa.Condition{
+		"c1": {{Op: dosa.Eq, Value: dosa.FieldValue(int64(1))}},
+	}, dosa.All(), "", 200)
+	assert.NoError(t, err)
+	assert.Len(t, data, 10)
+	assert.Empty(t, token)
+
+	// Get the "2" partition, should be empty
+	data, token, err = sut.Range(context.TODO(), clusteredEi, map[string][]*dosa.Condition{
+		"c1": {{Op: dosa.Eq, Value: dosa.FieldValue(int64(2))}},
+	}, dosa.All(), "", 200)
+	assert.NoError(t, err)
+	assert.Empty(t, data)
+	assert.Empty(t, token)
 }
 
 func TestConnector_TimeUUIDs(t *testing.T) {

--- a/registry.go
+++ b/registry.go
@@ -47,7 +47,7 @@ func NewRegisteredEntity(scope, prefix string, table *Table) *RegisteredEntity {
 			NamePrefix: prefix,
 			EntityName: table.Name,
 		},
-		Def: &(table.EntityDefinition),
+		Def: &table.EntityDefinition,
 	}
 	return &RegisteredEntity{
 		scope:  scope,

--- a/registry.go
+++ b/registry.go
@@ -47,11 +47,7 @@ func NewRegisteredEntity(scope, prefix string, table *Table) *RegisteredEntity {
 			NamePrefix: prefix,
 			EntityName: table.Name,
 		},
-		Def: &EntityDefinition{
-			Name:    table.Name,
-			Key:     table.Key,
-			Columns: table.Columns,
-		},
+		Def: &(table.EntityDefinition),
 	}
 	return &RegisteredEntity{
 		scope:  scope,

--- a/registry_test.go
+++ b/registry_test.go
@@ -69,6 +69,7 @@ func TestNewRegisteredEntity(t *testing.T) {
 	assert.Equal(t, ref.EntityName, entityName)
 	assert.Equal(t, ref.Version, version)
 	assert.Equal(t, def.Name, entityName)
+	assert.Equal(t, table.EntityDefinition, *def)
 }
 
 func TestRegisteredEntity_KeyFieldValues(t *testing.T) {


### PR DESCRIPTION
`NewRegisteredEntity` has a bug where the entity that get's registered doesn't properly copy over the secondary Indexes for a given `EntityDefintion`, it only sets the name, key, and columns.

This causes Range lookups on secondary indexes to fail for the in-memory connector.

Let's fix this problem by just using the full `EntityDefinition` that's available to us via the `table` that's passed in. This way, if we ever add any more fields to the `EntityDefinition` in the future, they'll be automatically included in the `RegisteredEntity`.