### PR TITLE
Provide convenience function for fetching entire range

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,10 +108,10 @@ else ifeq ($(target), Linux)
 endif
 endif
 
-mocks/client.go:
+mocks/client.go: client.go
 	mockgen -package mocks github.com/uber-go/dosa Client,AdminClient > ./mocks/client.go
 
-mocks/connector.go:
+mocks/connector.go: connector.go
 	mockgen -package mocks github.com/uber-go/dosa Connector > ./mocks/connector.go
 
 .PHONY: mocks

--- a/client.go
+++ b/client.go
@@ -163,9 +163,12 @@ type Client interface {
 	// of the range can be fetched with additional calls to the range function.
 	Range(ctx context.Context, rangeOp *RangeOp) ([]DomainObject, string, error)
 
-	// FetchRange fetches the entire range of values specified by the RangeOp. For each value fetched,
-	// the provided onNext function is called with the value as it's argument.
-	FetchRange(ctx context.Context, r *RangeOp, onNext func(value DomainObject) error) error
+	// RangeIter starts at the offset specified by the RangeOp and fetches the entire
+	// range of values that fall within the RangeOp conditions. It will make multiple, sequential
+	// range requests, fetching values until there are no more left in the range.
+	//
+	// For each value fetched, the provided onNext function is called with the value as it's argument.
+	RangeIter(ctx context.Context, r *RangeOp, onNext func(value DomainObject) error) error
 
 	// Search fetches entities by fields that have been marked "searchable"
 	// TODO: Coming in v2.1
@@ -445,7 +448,7 @@ func (c *client) Range(ctx context.Context, r *RangeOp) ([]DomainObject, string,
 	return objectArray, token, nil
 }
 
-func (c *client) FetchRange(ctx context.Context, r *RangeOp, onNext func(value DomainObject) error) error {
+func (c *client) RangeIter(ctx context.Context, r *RangeOp, onNext func(value DomainObject) error) error {
 	for {
 		results, nextToken, err := c.Range(ctx, r)
 

--- a/client.go
+++ b/client.go
@@ -156,8 +156,16 @@ type Client interface {
 	// Before calling range, create a RangeOp and fill in the table
 	// along with the partition key information. You will get back
 	// an array of DomainObjects, which will be of the type you requested
-	// in the rangeOp
+	// in the rangeOp.
+	//
+	// Range only fetches a portion of the range at a time (the size of that portion is defined
+	// by the Limit parameter of the RangeOp). A continuation token is returned so subsequent portions
+	// of the range can be fetched with additional calls to the range function.
 	Range(ctx context.Context, rangeOp *RangeOp) ([]DomainObject, string, error)
+
+	// FetchRange fetches the entire range of values specified by the RangeOp. For each value fetched,
+	// the provided onNext function is called with the value as it's argument.
+	FetchRange(ctx context.Context, r *RangeOp, onNext func(value DomainObject) error) error
 
 	// Search fetches entities by fields that have been marked "searchable"
 	// TODO: Coming in v2.1
@@ -435,6 +443,27 @@ func (c *client) Range(ctx context.Context, r *RangeOp) ([]DomainObject, string,
 
 	objectArray := objectsFromValueArray(r.sop.object, values, re, nil)
 	return objectArray, token, nil
+}
+
+func (c *client) FetchRange(ctx context.Context, r *RangeOp, onNext func(value DomainObject) error) error {
+	for {
+		results, nextToken, err := c.Range(ctx, r)
+
+		if err != nil {
+			return err
+		}
+
+		for _, result := range results {
+			if cerr := onNext(result); cerr != nil {
+				return cerr
+			}
+		}
+
+		if len(nextToken) == 0 {
+			return nil
+		}
+		r = r.Offset(nextToken)
+	}
 }
 
 func objectsFromValueArray(object DomainObject, values []map[string]FieldValue, re *RegisteredEntity, columnsToRead []string) []DomainObject {

--- a/client.go
+++ b/client.go
@@ -163,12 +163,12 @@ type Client interface {
 	// of the range can be fetched with additional calls to the range function.
 	Range(ctx context.Context, rangeOp *RangeOp) ([]DomainObject, string, error)
 
-	// RangeIter starts at the offset specified by the RangeOp and fetches the entire
+	// WalkRange starts at the offset specified by the RangeOp and walks the entire
 	// range of values that fall within the RangeOp conditions. It will make multiple, sequential
 	// range requests, fetching values until there are no more left in the range.
 	//
 	// For each value fetched, the provided onNext function is called with the value as it's argument.
-	RangeIter(ctx context.Context, r *RangeOp, onNext func(value DomainObject) error) error
+	WalkRange(ctx context.Context, r *RangeOp, onNext func(value DomainObject) error) error
 
 	// Search fetches entities by fields that have been marked "searchable"
 	// TODO: Coming in v2.1
@@ -448,7 +448,7 @@ func (c *client) Range(ctx context.Context, r *RangeOp) ([]DomainObject, string,
 	return objectArray, token, nil
 }
 
-func (c *client) RangeIter(ctx context.Context, r *RangeOp, onNext func(value DomainObject) error) error {
+func (c *client) WalkRange(ctx context.Context, r *RangeOp, onNext func(value DomainObject) error) error {
 	for {
 		results, nextToken, err := c.Range(ctx, r)
 

--- a/client_test.go
+++ b/client_test.go
@@ -432,7 +432,7 @@ func TestClient_Range(t *testing.T) {
 	assert.True(t, dosaRenamed.ErrorIsNotFound(err))
 }
 
-func TestClient_RangeIter(t *testing.T) {
+func TestClient_WalkRange(t *testing.T) {
 	reg1, _ := dosaRenamed.NewRegistrar(scope, namePrefix, cte1)
 	fieldsToRead := []string{"ID", "Email"}
 	resultRow0 := map[string]dosaRenamed.FieldValue{
@@ -449,7 +449,7 @@ func TestClient_RangeIter(t *testing.T) {
 	// uninitialized
 	c0 := dosaRenamed.NewClient(reg1, nullConnector)
 	rop := dosaRenamed.NewRangeOp(cte1).Fields(fieldsToRead).Eq("ID", "123").Offset("tokeytoketoke")
-	err := c0.RangeIter(ctx, rop, func(value dosaRenamed.DomainObject) error {
+	err := c0.WalkRange(ctx, rop, func(value dosaRenamed.DomainObject) error {
 		return nil
 	})
 	assert.True(t, dosaRenamed.ErrorIsNotInitialized(err))
@@ -468,7 +468,7 @@ func TestClient_RangeIter(t *testing.T) {
 	rop = dosaRenamed.NewRangeOp(cte1)
 
 	var fetched []*ClientTestEntity1
-	err = c1.RangeIter(ctx, rop, func(value dosaRenamed.DomainObject) error {
+	err = c1.WalkRange(ctx, rop, func(value dosaRenamed.DomainObject) error {
 		fetched = append(fetched, value.(*ClientTestEntity1))
 		return nil
 	})
@@ -490,7 +490,7 @@ func TestClient_RangeIter(t *testing.T) {
 	c2 := dosaRenamed.NewClient(reg1, mockConn2)
 	c2.Initialize(ctx)
 	rop = dosaRenamed.NewRangeOp(cte1)
-	err = c2.RangeIter(ctx, rop, func(value dosaRenamed.DomainObject) error {
+	err = c2.WalkRange(ctx, rop, func(value dosaRenamed.DomainObject) error {
 		return errors.New("woops!")
 	})
 	assert.EqualError(t, err, "woops!")

--- a/client_test.go
+++ b/client_test.go
@@ -432,7 +432,7 @@ func TestClient_Range(t *testing.T) {
 	assert.True(t, dosaRenamed.ErrorIsNotFound(err))
 }
 
-func TestClient_FetchRange(t *testing.T) {
+func TestClient_RangeIter(t *testing.T) {
 	reg1, _ := dosaRenamed.NewRegistrar(scope, namePrefix, cte1)
 	fieldsToRead := []string{"ID", "Email"}
 	resultRow0 := map[string]dosaRenamed.FieldValue{
@@ -449,7 +449,7 @@ func TestClient_FetchRange(t *testing.T) {
 	// uninitialized
 	c0 := dosaRenamed.NewClient(reg1, nullConnector)
 	rop := dosaRenamed.NewRangeOp(cte1).Fields(fieldsToRead).Eq("ID", "123").Offset("tokeytoketoke")
-	err := c0.FetchRange(ctx, rop, func(value dosaRenamed.DomainObject) error {
+	err := c0.RangeIter(ctx, rop, func(value dosaRenamed.DomainObject) error {
 		return nil
 	})
 	assert.True(t, dosaRenamed.ErrorIsNotInitialized(err))
@@ -468,7 +468,7 @@ func TestClient_FetchRange(t *testing.T) {
 	rop = dosaRenamed.NewRangeOp(cte1)
 
 	var fetched []*ClientTestEntity1
-	err = c1.FetchRange(ctx, rop, func(value dosaRenamed.DomainObject) error {
+	err = c1.RangeIter(ctx, rop, func(value dosaRenamed.DomainObject) error {
 		fetched = append(fetched, value.(*ClientTestEntity1))
 		return nil
 	})
@@ -490,7 +490,7 @@ func TestClient_FetchRange(t *testing.T) {
 	c2 := dosaRenamed.NewClient(reg1, mockConn2)
 	c2.Initialize(ctx)
 	rop = dosaRenamed.NewRangeOp(cte1)
-	err = c2.FetchRange(ctx, rop, func(value dosaRenamed.DomainObject) error {
+	err = c2.RangeIter(ctx, rop, func(value dosaRenamed.DomainObject) error {
 		return errors.New("woops!")
 	})
 	assert.EqualError(t, err, "woops!")

--- a/mocks/client.go
+++ b/mocks/client.go
@@ -88,17 +88,6 @@ func (_mr *_MockClientRecorder) Range(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Range", arg0, arg1)
 }
 
-// RangeIter is a mock implementation of MockClient.RangeIter
-func (_m *MockClient) RangeIter(_param0 context.Context, _param1 *dosa.RangeOp, _param2 func(dosa.DomainObject) error) error {
-	ret := _m.ctrl.Call(_m, "RangeIter", _param0, _param1, _param2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockClientRecorder) RangeIter(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RangeIter", arg0, arg1, arg2)
-}
-
 // Read is a mock implementation of MockClient.Read
 func (_m *MockClient) Read(_param0 context.Context, _param1 []string, _param2 dosa.DomainObject) error {
 	ret := _m.ctrl.Call(_m, "Read", _param0, _param1, _param2)
@@ -154,6 +143,17 @@ func (_m *MockClient) Upsert(_param0 context.Context, _param1 []string, _param2 
 
 func (_mr *_MockClientRecorder) Upsert(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Upsert", arg0, arg1, arg2)
+}
+
+// WalkRange is a mock implementation of MockClient.WalkRange
+func (_m *MockClient) WalkRange(_param0 context.Context, _param1 *dosa.RangeOp, _param2 func(dosa.DomainObject) error) error {
+	ret := _m.ctrl.Call(_m, "WalkRange", _param0, _param1, _param2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockClientRecorder) WalkRange(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WalkRange", arg0, arg1, arg2)
 }
 
 // MockAdminClient is a mock of AdminClient interface

--- a/mocks/client.go
+++ b/mocks/client.go
@@ -64,6 +64,17 @@ func (_mr *_MockClientRecorder) CreateIfNotExists(arg0, arg1 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateIfNotExists", arg0, arg1)
 }
 
+// FetchRange is a mock implementation of MockClient.FetchRange
+func (_m *MockClient) FetchRange(_param0 context.Context, _param1 *dosa.RangeOp, _param2 func(dosa.DomainObject) error) error {
+	ret := _m.ctrl.Call(_m, "FetchRange", _param0, _param1, _param2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockClientRecorder) FetchRange(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchRange", arg0, arg1, arg2)
+}
+
 // Initialize is a mock implementation of MockClient.Initialize
 func (_m *MockClient) Initialize(_param0 context.Context) error {
 	ret := _m.ctrl.Call(_m, "Initialize", _param0)

--- a/mocks/client.go
+++ b/mocks/client.go
@@ -64,17 +64,6 @@ func (_mr *_MockClientRecorder) CreateIfNotExists(arg0, arg1 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateIfNotExists", arg0, arg1)
 }
 
-// FetchRange is a mock implementation of MockClient.FetchRange
-func (_m *MockClient) FetchRange(_param0 context.Context, _param1 *dosa.RangeOp, _param2 func(dosa.DomainObject) error) error {
-	ret := _m.ctrl.Call(_m, "FetchRange", _param0, _param1, _param2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockClientRecorder) FetchRange(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchRange", arg0, arg1, arg2)
-}
-
 // Initialize is a mock implementation of MockClient.Initialize
 func (_m *MockClient) Initialize(_param0 context.Context) error {
 	ret := _m.ctrl.Call(_m, "Initialize", _param0)
@@ -97,6 +86,17 @@ func (_m *MockClient) Range(_param0 context.Context, _param1 *dosa.RangeOp) ([]d
 
 func (_mr *_MockClientRecorder) Range(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Range", arg0, arg1)
+}
+
+// RangeIter is a mock implementation of MockClient.RangeIter
+func (_m *MockClient) RangeIter(_param0 context.Context, _param1 *dosa.RangeOp, _param2 func(dosa.DomainObject) error) error {
+	ret := _m.ctrl.Call(_m, "RangeIter", _param0, _param1, _param2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockClientRecorder) RangeIter(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RangeIter", arg0, arg1, arg2)
 }
 
 // Read is a mock implementation of MockClient.Read


### PR DESCRIPTION
Customers often want to fetch an entire range of values. Doing so with the current `Range` function provided by the `Client` is tedious. It requires writing the same boiler plate code over, and over again. Let's provide a convenience function so that customers don't have to write their own.