### PR TITLE
Better RemoveRange API

### DIFF
--- a/client.go
+++ b/client.go
@@ -383,7 +383,7 @@ func (c *client) RemoveRange(ctx context.Context, r *RangeOp) error {
 	}
 
 	// look up the entity in the registry
-	re, err := c.registrar.Find(r.sop.object)
+	re, err := c.registrar.Find(r.object)
 	if err != nil {
 		return errors.Wrap(err, "RemoveRange")
 	}
@@ -410,7 +410,7 @@ func (c *client) Range(ctx context.Context, r *RangeOp) ([]DomainObject, string,
 		return nil, "", &ErrNotInitialized{}
 	}
 	// look up the entity in the registry
-	re, err := c.registrar.Find(r.sop.object)
+	re, err := c.registrar.Find(r.object)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "Range")
 	}
@@ -422,18 +422,18 @@ func (c *client) Range(ctx context.Context, r *RangeOp) ([]DomainObject, string,
 	}
 
 	// convert the fieldsToRead to the server side equivalent
-	fieldsToRead, err := re.ColumnNames(r.sop.fieldsToRead)
+	fieldsToRead, err := re.ColumnNames(r.fieldsToRead)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "Range")
 	}
 
 	// call the server side method
-	values, token, err := c.connector.Range(ctx, re.info, columnConditions, fieldsToRead, r.sop.token, r.sop.limit)
+	values, token, err := c.connector.Range(ctx, re.info, columnConditions, fieldsToRead, r.token, r.limit)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "Range")
 	}
 
-	objectArray := objectsFromValueArray(r.sop.object, values, re, nil)
+	objectArray := objectsFromValueArray(r.object, values, re, nil)
 	return objectArray, token, nil
 }
 

--- a/client.go
+++ b/client.go
@@ -142,10 +142,8 @@ type Client interface {
 	Remove(ctx context.Context, objectToRemove DomainObject) error
 
 	// RemoveRange removes all of the rows that fall within the range specified by the
-	// given RangeOp.
-	//
-	// Note that any Fields, Limit, or Offest on the given rangeOp are ignored by this function.
-	RemoveRange(ctx context.Context, rangeOp *RangeOp) error
+	// given RemoveRangeOp.
+	RemoveRange(ctx context.Context, removeRangeOp *RemoveRangeOp) error
 
 	// TODO: Coming in v2.1
 	// MultiRemove removes multiple rows by primary key. The passed-in entity should
@@ -374,10 +372,8 @@ func (c *client) Remove(ctx context.Context, entity DomainObject) error {
 }
 
 // RemoveRange removes all of the rows that fall within the range specified by the
-// given RangeOp.
-//
-// Note that any Fields, Limit, or Offest on the given rangeOp are ignored by this function.
-func (c *client) RemoveRange(ctx context.Context, r *RangeOp) error {
+// given RemoveRangeOp.
+func (c *client) RemoveRange(ctx context.Context, r *RemoveRangeOp) error {
 	if !c.initialized {
 		return &ErrNotInitialized{}
 	}
@@ -389,7 +385,7 @@ func (c *client) RemoveRange(ctx context.Context, r *RangeOp) error {
 	}
 
 	// now convert the client range columns to server side column conditions structure
-	columnConditions, err := convertRangeOpConditions(r, re.table)
+	columnConditions, err := convertConditions(r.conditions, re.table)
 	if err != nil {
 		return errors.Wrap(err, "RemoveRange")
 	}
@@ -416,7 +412,7 @@ func (c *client) Range(ctx context.Context, r *RangeOp) ([]DomainObject, string,
 	}
 
 	// now convert the client range columns to server side column conditions structure
-	columnConditions, err := convertRangeOpConditions(r, re.table)
+	columnConditions, err := convertConditions(r.conditions, re.table)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "Range")
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -335,20 +335,20 @@ func TestClient_RemoveRange(t *testing.T) {
 	reg1, _ := dosaRenamed.NewRegistrar(scope, namePrefix, cte1)
 
 	c1 := dosaRenamed.NewClient(reg1, nullConnector)
-	rop := dosaRenamed.NewRangeOp(cte1).Eq("ID", "123")
+	rop := dosaRenamed.NewRemoveRangeOp(cte1).Eq("ID", "123")
 	err := c1.RemoveRange(ctx, rop)
 	assert.True(t, dosaRenamed.ErrorIsNotInitialized(err))
 
 	c1.Initialize(ctx)
 
 	//bad entity
-	rop = dosaRenamed.NewRangeOp(cte2)
+	rop = dosaRenamed.NewRemoveRangeOp(cte2)
 	err = c1.RemoveRange(ctx, rop)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "ClientTestEntity2")
 
 	// bad column in range
-	rop = dosaRenamed.NewRangeOp(cte1).Eq("borkborkbork", int64(1))
+	rop = dosaRenamed.NewRemoveRangeOp(cte1).Eq("borkborkbork", int64(1))
 	err = c1.RemoveRange(ctx, rop)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "ClientTestEntity1")
@@ -362,7 +362,7 @@ func TestClient_RemoveRange(t *testing.T) {
 	mockConn.EXPECT().RemoveRange(ctx, gomock.Any(), gomock.Any()).Return(nil)
 	c2 := dosaRenamed.NewClient(reg1, mockConn)
 	c2.Initialize(ctx)
-	rop = dosaRenamed.NewRangeOp(cte1)
+	rop = dosaRenamed.NewRemoveRangeOp(cte1)
 	err = c2.RemoveRange(ctx, rop)
 	assert.NoError(t, err)
 }

--- a/conditioner.go
+++ b/conditioner.go
@@ -1,0 +1,32 @@
+package dosa
+
+import "github.com/pkg/errors"
+
+type conditioner struct {
+	object     DomainObject
+	conditions map[string][]*Condition
+}
+
+func (c *conditioner) appendOp(op Operator, fieldName string, value interface{}) {
+	c.conditions[fieldName] = append(c.conditions[fieldName], &Condition{Op: op, Value: value})
+}
+
+// convertConditions converts a list of client field names to server side field names
+func convertConditions(conditions map[string][]*Condition, t *Table) (map[string][]*Condition, error) {
+	serverConditions := map[string][]*Condition{}
+	for colName, conds := range conditions {
+		if scolName, ok := t.FieldToCol[colName]; ok {
+			serverConditions[scolName] = conds
+			// we need to be sure each of the types are correct for marshaling
+			cd := t.FindColumnDefinition(scolName)
+			for _, cond := range conds {
+				if err := ensureTypeMatch(cd.Type, cond.Value); err != nil {
+					return nil, errors.Wrapf(err, "column %s", colName)
+				}
+			}
+		} else {
+			return nil, errors.Errorf("Cannot find column %q in struct %q", colName, t.StructName)
+		}
+	}
+	return serverConditions, nil
+}

--- a/conditioner_test.go
+++ b/conditioner_test.go
@@ -1,0 +1,26 @@
+package dosa
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertConditions(t *testing.T) {
+	alltypesTable, _ := TableFromInstance((*AllTypes)(nil))
+	for _, test := range rangeTestCases {
+		result, err := convertConditions(test.rop.conditions, alltypesTable)
+		if err != nil {
+			assert.Contains(t, err.Error(), test.err, test.descript)
+		} else {
+			if assert.NoError(t, err) {
+				// we don't have a stringify method on just the conditions bit
+				// so just build a new RangeOp from the old one
+				newRop := *test.rop
+				newRop.conditions = result
+				final := (&newRop).String()
+				assert.Equal(t, test.converted, final, test.descript)
+			}
+		}
+	}
+}

--- a/mocks/client.go
+++ b/mocks/client.go
@@ -25,7 +25,6 @@ package mocks
 
 import (
 	context "context"
-
 	gomock "github.com/golang/mock/gomock"
 	dosa "github.com/uber-go/dosa"
 )
@@ -111,7 +110,7 @@ func (_mr *_MockClientRecorder) Remove(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // RemoveRange is a mock implementation of MockClient.RemoveRange
-func (_m *MockClient) RemoveRange(_param0 context.Context, _param1 *dosa.RangeOp) error {
+func (_m *MockClient) RemoveRange(_param0 context.Context, _param1 *dosa.RemoveRangeOp) error {
 	ret := _m.ctrl.Call(_m, "RemoveRange", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/pager.go
+++ b/pager.go
@@ -1,0 +1,35 @@
+package dosa
+
+import (
+	"fmt"
+	"io"
+)
+
+type pager struct {
+	limit        int
+	token        string
+	fieldsToRead []string
+}
+
+func addLimitTokenString(w io.Writer, limit int, token string) {
+	if limit > 0 {
+		fmt.Fprintf(w, " limit %d", limit)
+	}
+	if token != "" {
+		fmt.Fprintf(w, " token %q", token)
+	}
+}
+
+func (p pager) equals(p2 pager) bool {
+	if len(p.fieldsToRead) != len(p2.fieldsToRead) {
+		return false
+	}
+
+	for i, field := range p.fieldsToRead {
+		if p2.fieldsToRead[i] != field {
+			return false
+		}
+	}
+
+	return p.limit == p2.limit && p.token == p2.token
+}

--- a/range.go
+++ b/range.go
@@ -23,6 +23,7 @@ package dosa
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"sort"
 
 	"github.com/golang/mock/gomock"
@@ -31,14 +32,37 @@ import (
 
 // RangeOp is used to specify constraints to Range calls
 type RangeOp struct {
-	sop        ScanOp
+	pager
+	object     DomainObject
 	conditions map[string][]*Condition
 }
 
 // NewRangeOp returns a new RangeOp instance
 func NewRangeOp(object DomainObject) *RangeOp {
-	rop := &RangeOp{conditions: map[string][]*Condition{}, sop: ScanOp{object: object}}
+	rop := &RangeOp{
+		object:     object,
+		conditions: map[string][]*Condition{},
+	}
 	return rop
+}
+
+// Limit sets the number of rows returned per call. Default is 100
+func (r *RangeOp) Limit(n int) *RangeOp {
+	r.limit = n
+	return r
+}
+
+// Offset sets the pagination token. If not set, an empty token would be used.
+func (r *RangeOp) Offset(token string) *RangeOp {
+	r.token = token
+	return r
+}
+
+// Fields list the non-key fields users want to fetch.
+// PrimaryKey fields are always fetched.
+func (r *RangeOp) Fields(fields []string) *RangeOp {
+	r.fieldsToRead = fields
+	return r
 }
 
 // String satisfies the Stringer interface
@@ -68,7 +92,7 @@ func (r *RangeOp) String() string {
 			}
 		}
 	}
-	addLimitTokenString(result, r.sop.limit, r.sop.token)
+	addLimitTokenString(result, r.limit, r.token)
 	return result.String()
 }
 
@@ -104,27 +128,6 @@ func (r *RangeOp) LtOrEq(fieldName string, value interface{}) *RangeOp {
 	return r.appendOp(LtOrEq, fieldName, value)
 }
 
-// Fields list the non-key fields users want to fetch. If not set, all fields would be fetched.
-// PrimaryKey fields are always fetched.
-func (r *RangeOp) Fields(fieldsToRead []string) *RangeOp {
-	r.sop.fieldsToRead = fieldsToRead
-	return r
-}
-
-// Limit sets the number of rows returned per call. A limit must be provided.
-// If a limit is not provided, an error will be generated at query
-// execution-time.
-func (r *RangeOp) Limit(n int) *RangeOp {
-	r.sop.limit = n
-	return r
-}
-
-// Offset sets the pagination token. If not set, an empty token would be used.
-func (r *RangeOp) Offset(token string) *RangeOp {
-	r.sop.token = token
-	return r
-}
-
 // convertRangeOp converts a list of client field names to server side field names
 //
 func convertRangeOpConditions(r *RangeOp, t *Table) (map[string][]*Condition, error) {
@@ -147,8 +150,9 @@ func convertRangeOpConditions(r *RangeOp, t *Table) (map[string][]*Condition, er
 }
 
 type rangeOpMatcher struct {
-	conds    map[string]map[Condition]bool
-	eqScanOp gomock.Matcher
+	conds map[string]map[Condition]bool
+	p     pager
+	typ   reflect.Type
 }
 
 // EqRangeOp creates a gomock Matcher that will match any RangeOp with the same conditions, limit, token, and fields
@@ -163,8 +167,9 @@ func EqRangeOp(op *RangeOp) gomock.Matcher {
 	}
 
 	return rangeOpMatcher{
-		conds:    conds,
-		eqScanOp: EqScanOp(&(op.sop)),
+		conds: conds,
+		p:     op.pager,
+		typ:   reflect.TypeOf(op.object).Elem(),
 	}
 }
 
@@ -183,19 +188,18 @@ func (m rangeOpMatcher) Matches(x interface{}) bool {
 		}
 	}
 
-	if !m.eqScanOp.Matches(&(op.sop)) {
-		return false
-	}
-	return true
+	return m.p.equals(op.pager) && reflect.TypeOf(op.object).Elem() == m.typ
 }
 
 // String satisfies the gomock.Matcher and Stringer interface
 func (m rangeOpMatcher) String() string {
 	return fmt.Sprintf(
-		" is equal to RangeOp with conditions %v, and scan op %s",
+		" is equal to RangeOp with conditions %v, token %s, limit %d, fields %v, and entity type %v",
 		m.conds,
-		m.eqScanOp.String(),
-	)
+		m.p.token,
+		m.p.limit,
+		m.p.fieldsToRead,
+		m.typ)
 }
 
 // IndexFromConditions returns the name of the index or the base table to use, along with the key info

--- a/range_test.go
+++ b/range_test.go
@@ -131,11 +131,13 @@ func TestRangeOpMatcher(t *testing.T) {
 	RangeOp2 := NewRangeOp(&AllTypes{}).Lt("StringType", "Hello")
 	RangeOp3 := NewRangeOp(&AllTypes{}).Eq("StringType", "Hello").Offset("token1")
 	RangeOp4 := NewRangeOp(&AllTypes{}).Eq("StringType", "Hello").Limit(5)
+	RangeOp5 := NewRangeOp(&AllTypes{}).Eq("StringType", "Hello").Fields([]string{"BoolType"})
 
 	matcher := EqRangeOp(RangeOp0)
 	assert.True(t, matcher.Matches(RangeOp1))
 	assert.False(t, matcher.Matches(RangeOp2))
 	assert.False(t, matcher.Matches(RangeOp3))
 	assert.False(t, matcher.Matches(RangeOp4))
+	assert.False(t, matcher.Matches(RangeOp5))
 	assert.False(t, matcher.Matches(3))
 }

--- a/range_test.go
+++ b/range_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var RangeTestCases = []struct {
+var rangeTestCases = []struct {
 	descript  string
 	rop       *RangeOp
 	stringer  string
@@ -101,27 +101,8 @@ func TestNewRangeOp(t *testing.T) {
 
 func TestRangeOpStringer(t *testing.T) {
 
-	for _, test := range RangeTestCases {
+	for _, test := range rangeTestCases {
 		assert.Equal(t, test.stringer, test.rop.String(), test.descript)
-	}
-}
-
-func TestConvertRangeOpConditions(t *testing.T) {
-	alltypesTable, _ := TableFromInstance((*AllTypes)(nil))
-	for _, test := range RangeTestCases {
-		result, err := convertRangeOpConditions(test.rop, alltypesTable)
-		if err != nil {
-			assert.Contains(t, err.Error(), test.err, test.descript)
-		} else {
-			if assert.NoError(t, err) {
-				// we don't have a stringify method on just the conditions bit
-				// so just build a new RangeOp from the old one
-				newRop := *test.rop
-				newRop.conditions = result
-				final := (&newRop).String()
-				assert.Equal(t, test.converted, final, test.descript)
-			}
-		}
 	}
 }
 

--- a/remove_range.go
+++ b/remove_range.go
@@ -1,0 +1,49 @@
+package dosa
+
+// RemoveRangeOp is used to specify contraints on RemoveRange calls
+type RemoveRangeOp struct {
+	conditioner
+}
+
+// NewRemoveRangeOp returns a new RangeOp instance
+func NewRemoveRangeOp(object DomainObject) *RemoveRangeOp {
+	rop := &RemoveRangeOp{
+		conditioner: conditioner{
+			object:     object,
+			conditions: map[string][]*Condition{},
+		},
+	}
+	return rop
+}
+
+// Eq is used to express an equality constraint for a remove range operation
+func (r *RemoveRangeOp) Eq(fieldName string, value interface{}) *RemoveRangeOp {
+	r.appendOp(Eq, fieldName, value)
+	return r
+}
+
+// Gt is used to express an "greater than" constraint for a remove range operation
+func (r *RemoveRangeOp) Gt(fieldName string, value interface{}) *RemoveRangeOp {
+	r.appendOp(Gt, fieldName, value)
+	return r
+}
+
+// GtOrEq is used to express an "greater than or equal" constraint for a
+// remove range operation
+func (r *RemoveRangeOp) GtOrEq(fieldName string, value interface{}) *RemoveRangeOp {
+	r.appendOp(GtOrEq, fieldName, value)
+	return r
+}
+
+// Lt is used to express a "less than" constraint for a remove range operation
+func (r *RemoveRangeOp) Lt(fieldName string, value interface{}) *RemoveRangeOp {
+	r.appendOp(Lt, fieldName, value)
+	return r
+}
+
+// LtOrEq is used to express a "less than or equal" constraint for a
+// remove range operation
+func (r *RemoveRangeOp) LtOrEq(fieldName string, value interface{}) *RemoveRangeOp {
+	r.appendOp(LtOrEq, fieldName, value)
+	return r
+}

--- a/remove_range_test.go
+++ b/remove_range_test.go
@@ -1,0 +1,57 @@
+package dosa
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type removeRangeTestCase struct {
+	desc          string
+	op            *RemoveRangeOp
+	expectedConds map[string][]*Condition
+}
+
+var removeRangeTestCases = []removeRangeTestCase{
+	{
+		desc: "Equal",
+		op:   NewRemoveRangeOp(&AllTypes{}).Eq("StringType", "hello"),
+		expectedConds: map[string][]*Condition{
+			"StringType": {{Op: Eq, Value: "hello"}},
+		},
+	},
+	{
+		desc: "Less than and Greater Than",
+		op:   NewRemoveRangeOp(&AllTypes{}).Lt("Int32Type", int32(4)).Gt("Int32Type", int32(1)),
+		expectedConds: map[string][]*Condition{
+			"Int32Type": {{Op: Lt, Value: int32(4)}, {Op: Gt, Value: int32(1)}},
+		},
+	},
+	{
+		desc: "Less than or equal to and greater than or equal to",
+		op:   NewRemoveRangeOp(&AllTypes{}).LtOrEq("Int32Type", int32(4)).GtOrEq("Int32Type", int32(1)),
+		expectedConds: map[string][]*Condition{
+			"Int32Type": {{Op: LtOrEq, Value: int32(4)}, {Op: GtOrEq, Value: int32(1)}},
+		},
+	},
+}
+
+func TestRemoveRangeConditions(t *testing.T) {
+	for _, test := range removeRangeTestCases {
+		t.Run(fmt.Sprintf("Test %s", test.desc), func(t *testing.T) {
+			removeRangeTest(t, test)
+		})
+	}
+}
+
+func removeRangeTest(t *testing.T, test removeRangeTestCase) {
+	assert.Equal(t, len(test.expectedConds), len(test.op.conditions))
+	for col, expConds := range test.expectedConds {
+		conds := test.op.conditions[col]
+		assert.Equal(t, len(expConds), len(conds))
+		for i, expCond := range expConds {
+			assert.Equal(t, expCond, conds[i])
+		}
+	}
+}


### PR DESCRIPTION
Couple things

1. The `RangeOp` has a `ScanOp` inside it. This is kinda weird. I can see why it was done, since they share so many similarities, however, I don't think this is the best way to organize the code. Let's extract their common aspects out into a struct called a `pager`. Now, both a `ScanOp` and a `RangeOp` have a pager embedded in them. This makes more sense.

2. Now that we've got `RangeOp` and `ScanOp` untangled, let's actually not use `RangeOp` for the `RemoveRange` api anymore. Using the `RangeOp` for `RemoveRange` is misleading because `RemoveRange` completely ignores the `token`, `limit`, and `fieldsToRead` aspects of `RangeOp`. Instead, let's extract their common components into a shared, embedded struct called a `conditioner`, and create a new `RemoveRangeOp` struct specifically for the `RemoveRange` API.

I've split these two changes up into two different commits so they're easier to review.