### PR TITLE
Fix RemoveRange panic with index criteria

### DIFF
--- a/connectors/memory/memory.go
+++ b/connectors/memory/memory.go
@@ -403,11 +403,10 @@ func (c *Connector) RemoveRange(_ context.Context, ei *dosa.EntityInfo, columnCo
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	partitionRange, err := c.findRange(ei, columnConditions)
+	partitionRange, err := c.findRange(ei, columnConditions, false)
 	if err != nil {
 		return err
 	}
-	// TODO: this should have been from a primary key lookup, not an index lookup
 	if partitionRange != nil {
 		for iName, iDef := range ei.Def.Indexes {
 			for _, vals := range partitionRange.values() {
@@ -425,7 +424,7 @@ func (c *Connector) Range(_ context.Context, ei *dosa.EntityInfo, columnConditio
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
-	partitionRange, err := c.findRange(ei, columnConditions)
+	partitionRange, err := c.findRange(ei, columnConditions, true)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "Invalid range conditions")
 	}
@@ -485,7 +484,7 @@ func decodeToken(token string) (values map[string]dosa.FieldValue, err error) {
 //
 // Note that this function reads from the connector's data map. Any calling functions should hold
 // at least a read lock on the map.
-func (c *Connector) findRange(ei *dosa.EntityInfo, columnConditions map[string][]*dosa.Condition) (*partitionRange, error) {
+func (c *Connector) findRange(ei *dosa.EntityInfo, columnConditions map[string][]*dosa.Condition, searchIndexes bool) (*partitionRange, error) {
 	// no data at all, fine
 	if c.data[ei.Def.Name] == nil {
 		return nil, nil
@@ -495,7 +494,7 @@ func (c *Connector) findRange(ei *dosa.EntityInfo, columnConditions map[string][
 	values := make(map[string]dosa.FieldValue)
 
 	// figure out which "table" or "index" to use based on the supplied conditions
-	name, key, err := ei.IndexFromConditions(columnConditions)
+	name, key, err := ei.IndexFromConditions(columnConditions, searchIndexes)
 	if err != nil {
 		return nil, err
 	}

--- a/connectors/memory/memory_test.go
+++ b/connectors/memory/memory_test.go
@@ -939,6 +939,20 @@ func TestConnector_RangeWithBadCriteria(t *testing.T) {
 	assert.Error(t, err)
 
 }
+func TestConnector_RemoveRangeWithSecondaryIndex(t *testing.T) {
+	sut := NewConnector()
+	// we don't look at the criteria unless there is at least one row
+	createTestData(t, sut, func(id int) string {
+		return "data"
+	}, 1)
+
+	err := sut.RemoveRange(context.TODO(), clusteredEi, map[string][]*dosa.Condition{
+		"c1": {{Op: dosa.Eq, Value: dosa.FieldValue(int64(1))}},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "f1")
+	assert.Contains(t, err.Error(),"partition key")
+}
 
 // createTestData populates some test data. The keyGenFunc can either return a constant,
 // which gives you a single partition of data, or some function of the current offset, which

--- a/range.go
+++ b/range.go
@@ -184,14 +184,14 @@ func (m rangeOpMatcher) String() string {
 
 // IndexFromConditions returns the name of the index or the base table to use, along with the key info
 // for that index. If no suitable index could be found, an error is returned
-func (ei *EntityInfo) IndexFromConditions(conditions map[string][]*Condition) (name string, key *PrimaryKey, err error) {
+func (ei *EntityInfo) IndexFromConditions(conditions map[string][]*Condition, searchIndexes bool) (name string, key *PrimaryKey, err error) {
 	identityFunc := func(s string) string { return s }
 	// see if we match the primary key for this table
 	var baseTableError error
 	if baseTableError = EnsureValidRangeConditions(ei.Def, ei.Def.Key, conditions, identityFunc); baseTableError == nil {
 		return ei.Def.Name, ei.Def.Key, nil
 	}
-	if len(ei.Def.Indexes) == 0 {
+	if searchIndexes == false || len(ei.Def.Indexes) == 0 {
 		return "", nil, baseTableError
 	}
 	// see if we match an index on this table


### PR DESCRIPTION
It's illegal to remove multiple items based on an index. This change
enforces that, by not looking at indexes when calling RemoveRange.