### PR TITLE
Remove dev-gateway

### DIFF
--- a/cmd/dosa/main.go
+++ b/cmd/dosa/main.go
@@ -63,7 +63,7 @@ type GlobalOptions struct {
 	Host        string     `long:"host" default:"127.0.0.1" description:"The hostname or IP for the gateway."`
 	Port        string     `short:"p" long:"port" default:"21300" description:"The hostname or IP for the gateway."`
 	Transport   string     `long:"transport" default:"tchannel" description:"TCP Transport to use. Options: http, tchannel."`
-	ServiceName string     `long:"service" description:"The TChannel service name for the gateway."`
+	ServiceName string     `short:"s" long:"service" default:"dosa-gateway" description:"The TChannel service name for the gateway."`
 	CallerName  callerFlag `long:"caller" default:"dosacli-$USER" description:"Caller will override the default caller name (which is dosacli-$USER)."`
 	Timeout     timeFlag   `long:"timeout" default:"60s" description:"The timeout for gateway requests. E.g., 100ms, 0.5s, 1s. If no unit is specified, milliseconds are assumed."`
 	Connector   string     `hidden:"true" long:"connector" default:"yarpc" description:"Name of connector to use"`

--- a/cmd/dosa/options.go
+++ b/cmd/dosa/options.go
@@ -32,9 +32,9 @@ import (
 )
 
 const (
-	_defServiceName  = "dosa-dev-gateway"
-	_prodServiceName = "dosa-gateway"
-	_prodScope       = "production"
+	_defHost        = "127.0.0.1"
+	_defPort        = "5437"
+	_defServiceName = "dosa-gateway"
 )
 
 var validNameRegex = regexp.MustCompile("^[a-z]+([a-z0-9]|[^-]-)*[^-]$")

--- a/cmd/dosa/options.go
+++ b/cmd/dosa/options.go
@@ -31,11 +31,7 @@ import (
 	"github.com/uber-go/dosa"
 )
 
-const (
-	_defHost        = "127.0.0.1"
-	_defPort        = "5437"
-	_defServiceName = "dosa-gateway"
-)
+const _defServiceName = "dosa-gateway"
 
 var validNameRegex = regexp.MustCompile("^[a-z]+([a-z0-9]|[^-]-)*[^-]$")
 

--- a/cmd/dosa/schema.go
+++ b/cmd/dosa/schema.go
@@ -79,12 +79,9 @@ func (c *SchemaCmd) doSchemaOp(name string, f func(dosa.AdminClient, context.Con
 		fmt.Printf("global options are %+v\n", options)
 	}
 
-	// if not given, set the service name dynamically based on scope
+	// TODO(eculver): use options/configurator pattern to apply defaults
 	if options.ServiceName == "" {
 		options.ServiceName = _defServiceName
-		if c.Scope == _prodScope {
-			options.ServiceName = _prodServiceName
-		}
 	}
 
 	client, err := getAdminClient(options)
@@ -161,12 +158,9 @@ func (c *SchemaStatus) Execute(args []string) error {
 		fmt.Printf("global options are %+v\n", options)
 	}
 
-	// if not given, set the service name dynamically based on scope
+	// TODO(eculver): use options/configurator pattern to apply defaults
 	if options.ServiceName == "" {
 		options.ServiceName = _defServiceName
-		if c.Scope == _prodScope {
-			options.ServiceName = _prodServiceName
-		}
 	}
 
 	client, err := getAdminClient(options)

--- a/cmd/dosa/schema_test.go
+++ b/cmd/dosa/schema_test.go
@@ -111,45 +111,21 @@ func TestSchema_ExpandDirectories(t *testing.T) {
 	os.Chdir("..")
 }
 
-func TestSchema_ServiceInference(t *testing.T) {
+func TestSchema_Defaults(t *testing.T) {
 	tcs := []struct {
 		serviceName string
-		scope       string
 		expected    string
 	}{
-		//  service = "", scope = "" -> default
+		//  service = "" -> default
 		{
 			expected: _defServiceName,
 		},
-		//  service = "", scope != prod -> default
-		{
-			scope:    "not-production",
-			expected: _defServiceName,
-		},
-		//  service = "", scope = prod -> prod
-		{
-			scope:    _prodScope,
-			expected: _prodServiceName,
-		},
-		//  service = "foo", scope = "" -> "foo"
+		//  service = "foo" -> foo
 		{
 			serviceName: "foo",
 			expected:    "foo",
 		},
-		//  service = "bar", scope != prod -> "bar"
-		{
-			serviceName: "bar",
-			scope:       "bar",
-			expected:    "bar",
-		},
-		//  service = "baz", scope = prod -> "baz"
-		{
-			serviceName: "baz",
-			scope:       _prodScope,
-			expected:    "baz",
-		},
 	}
-
 	for _, tc := range tcs {
 		for _, cmd := range []string{"check", "upsert", "status"} {
 			os.Args = []string{
@@ -159,7 +135,7 @@ func TestSchema_ServiceInference(t *testing.T) {
 				"schema",
 				cmd,
 				"--prefix", "foo",
-				"--scope", tc.scope,
+				"--scope", "bar",
 				"../../testentity",
 			}
 			main()

--- a/cmd/dosa/scope.go
+++ b/cmd/dosa/scope.go
@@ -35,11 +35,9 @@ type ScopeOptions struct{}
 type ScopeCmd struct{}
 
 func (c *ScopeCmd) doScopeOp(name string, f func(dosa.AdminClient, context.Context, string) error, scopes []string) error {
-	// set default service name if one isn't provided, this is done here instead
-	// of in the struct tags because schema and scope commands differ slightly
-	// in how the service name should be inferred.
+	// TODO(eculver): use options/configurator pattern to apply defaults
 	if options.ServiceName == "" {
-		options.ServiceName = _defServiceName // defined in options.go
+		options.ServiceName = _defServiceName
 	}
 
 	client, err := getAdminClient(options)


### PR DESCRIPTION
This removes all references to `dosa-dev-gateway` from the CLI and updates the defaults to use `dosa-gateway`. Users can still provide a service override if they choose to use `dosa-dev-gateway` but this is just another step in completely deprecating all notions of being _dev_ (vs prod) specific.