### PR TITLE
add testclient to DOSA

### DIFF
--- a/testclient/testclient.go
+++ b/testclient/testclient.go
@@ -1,0 +1,16 @@
+package testclient
+
+import (
+	"github.com/uber-go/dosa"
+	"github.com/uber-go/dosa/connectors/memory"
+)
+
+// NewTestClient creates a DOSA client useful for testing.
+func NewTestClient(scope, prefix string, entities ...dosa.DomainObject) (dosa.Client, error) {
+	reg, err := dosa.NewRegistrar(scope, prefix, entities...)
+	if err != nil {
+		return nil, err
+	}
+	connector := memory.NewConnector()
+	return dosa.NewClient(reg, connector), nil
+}

--- a/testclient/testclient_test.go
+++ b/testclient/testclient_test.go
@@ -1,0 +1,40 @@
+package testclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/dosa"
+	"github.com/uber-go/dosa/testentity"
+)
+
+func TestTestClient(t *testing.T) {
+	client, err := NewTestClient("testscope", "testprefix", &testentity.TestEntity{})
+	assert.NoError(t, err)
+
+	err = client.Initialize(context.Background())
+	assert.NoError(t, err)
+
+	uuid := dosa.NewUUID()
+	testEnt := testentity.TestEntity{
+		UUIDKey:  uuid,
+		StrKey:   "key",
+		Int64Key: 1,
+		StrV:     "hello",
+	}
+
+	err = client.Upsert(context.Background(), nil, &testEnt)
+	assert.NoError(t, err)
+
+	readEnt := testentity.TestEntity{
+		UUIDKey:  uuid,
+		StrKey:   "key",
+		Int64Key: 1,
+	}
+
+	err = client.Read(context.Background(), nil, &readEnt)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "hello", readEnt.StrV)
+}


### PR DESCRIPTION
This creates a simple DOSA client useful for testing that can't be done with simple mocks. This client utilizes the in-memory connector as it's backing store.