### PR TITLE
Fix yarpc tests

### DIFF
--- a/connectors/yarpc/yarpc_test.go
+++ b/connectors/yarpc/yarpc_test.go
@@ -831,6 +831,13 @@ func TestConnector_Scan(t *testing.T) {
 	testutil.AssertEqForPointer(testAssert(t), int64(1), values[0]["c1"])
 	testutil.AssertEqForPointer(testAssert(t), float64(2.2), values[0]["c2"])
 
+	// perform a generic error request
+	values, token, err = sut.Scan(ctx, testEi, nil, "", 64)
+	assert.Nil(t, values)
+	assert.Empty(t, token)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "test error")
+
 	// perform a not found request
 	values, token, err = sut.Scan(ctx, testEi, nil, "", 64)
 	assert.Nil(t, values)
@@ -838,12 +845,6 @@ func TestConnector_Scan(t *testing.T) {
 	assert.Error(t, err)
 	assert.True(t, dosa.ErrorIsNotFound(err))
 
-	// perform a generic error request
-	values, token, err = sut.Scan(ctx, testEi, nil, "", 64)
-	assert.Nil(t, values)
-	assert.Empty(t, token)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "test error")
 }
 
 func TestConnector_Remove(t *testing.T) {


### PR DESCRIPTION
Some how the tests for scan got out of order. If you look at the ordering of the mock responses for scan on lines 816 and 819 you'll see what we really should be doing is testing the generic error case first and then the not found error case.