### PR TITLE
Support time.Time in the in-memory connector

### DIFF
--- a/connectors/memory/memory.go
+++ b/connectors/memory/memory.go
@@ -476,6 +476,7 @@ func decodeToken(token string) (values map[string]dosa.FieldValue, err error) {
 	}
 	gobReader := bytes.NewBuffer(gobData)
 	gob.Register(dosa.UUID(""))
+	gob.Register(time.Time{})
 	decoder := gob.NewDecoder(gobReader)
 	err = decoder.Decode(&values)
 	return values, err

--- a/connectors/memory/memory.go
+++ b/connectors/memory/memory.go
@@ -459,6 +459,7 @@ func makeToken(v map[string]dosa.FieldValue) string {
 	encodedKey := bytes.Buffer{}
 	encoder := gob.NewEncoder(&encodedKey)
 	gob.Register(dosa.UUID(""))
+	gob.Register(time.Time{})
 	err := encoder.Encode(v)
 	if err != nil {
 		// this should really be impossible, unless someone forgot to

--- a/connectors/memory/memory_test.go
+++ b/connectors/memory/memory_test.go
@@ -102,8 +102,6 @@ var clusteredByTimeEi = &dosa.EntityInfo{
 			},
 		},
 		Name: "t3",
-		Indexes: map[string]*dosa.IndexDefinition{
-			"i3": {Key: &dosa.PrimaryKey{PartitionKeys: []string{"c1"}}}},
 	},
 }
 


### PR DESCRIPTION
This diff registers time.Time in the `makeToken` and `decodeToken` functions, allowing the `Scan` and other functions to support `time.Time`.

Fixes T1305491