### PR TITLE
Ensure index name is exported in the entity during schema validation 

### DIFF
--- a/entity_parser.go
+++ b/entity_parser.go
@@ -274,7 +274,7 @@ func parseIndexTag(indexName, dosaAnnotation string) (string, *PrimaryKey, error
 	if len(indexName) != 0 && unicode.IsLower([]rune(indexName)[0]) {
 		expected := []rune(indexName)
 		expected[0] = unicode.ToUpper(expected[0])
-		return "", nil, fmt.Errorf("index name (%s) must be exported, " +
+		return "", nil, fmt.Errorf("index name (%s) must be exported, "+
 			"try (%s) instead", indexName, string(expected))
 	}
 	tag := dosaAnnotation

--- a/entity_parser.go
+++ b/entity_parser.go
@@ -269,10 +269,7 @@ func translateKeyName(t *Table) {
 
 // parseIndexTag functions parses DOSA index tag
 func parseIndexTag(indexName, dosaAnnotation string) (string, *PrimaryKey, error) {
-	if len(indexName) == 0 {
-		return "", nil, fmt.Errorf("index name is empty")
-	}
-	if !unicode.IsUpper([]rune(indexName)[0]) {
+	if len(indexName) != 0 && !unicode.IsUpper([]rune(indexName)[0]) {
 		return "", nil, fmt.Errorf("index name (%s) must be exported", indexName)
 	}
 	tag := dosaAnnotation

--- a/entity_parser.go
+++ b/entity_parser.go
@@ -274,8 +274,8 @@ func parseIndexTag(indexName, dosaAnnotation string) (string, *PrimaryKey, error
 	if len(indexName) != 0 && unicode.IsLower([]rune(indexName)[0]) {
 		expected := []rune(indexName)
 		expected[0] = unicode.ToUpper(expected[0])
-		return "", nil, fmt.Errorf("index name (%s) must be exported, try (%s) instead",
-			indexName, string(expected))
+		return "", nil, fmt.Errorf("index name (%s) must be exported, " +
+			"try (%s) instead", indexName, string(expected))
 	}
 	tag := dosaAnnotation
 	// find the primaryKey

--- a/entity_parser.go
+++ b/entity_parser.go
@@ -269,6 +269,8 @@ func translateKeyName(t *Table) {
 
 // parseIndexTag functions parses DOSA index tag
 func parseIndexTag(indexName, dosaAnnotation string) (string, *PrimaryKey, error) {
+	// index name struct must be exported in the entity,
+	// otherwise it will be ignored when upserting the schema.
 	if len(indexName) != 0 && !unicode.IsUpper([]rune(indexName)[0]) {
 		return "", nil, fmt.Errorf("index name (%s) must be exported", indexName)
 	}

--- a/entity_parser.go
+++ b/entity_parser.go
@@ -271,8 +271,11 @@ func translateKeyName(t *Table) {
 func parseIndexTag(indexName, dosaAnnotation string) (string, *PrimaryKey, error) {
 	// index name struct must be exported in the entity,
 	// otherwise it will be ignored when upserting the schema.
-	if len(indexName) != 0 && !unicode.IsUpper([]rune(indexName)[0]) {
-		return "", nil, fmt.Errorf("index name (%s) must be exported", indexName)
+	if len(indexName) != 0 && unicode.IsLower([]rune(indexName)[0]) {
+		expected := []rune(indexName)
+		expected[0] = unicode.ToUpper(expected[0])
+		return "", nil, fmt.Errorf("index name (%s) must be exported, try (%s) instead",
+			indexName, string(expected))
 	}
 	tag := dosaAnnotation
 	// find the primaryKey

--- a/entity_parser.go
+++ b/entity_parser.go
@@ -25,8 +25,8 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
-
 	"time"
+	"unicode"
 
 	"github.com/pkg/errors"
 )
@@ -269,6 +269,12 @@ func translateKeyName(t *Table) {
 
 // parseIndexTag functions parses DOSA index tag
 func parseIndexTag(indexName, dosaAnnotation string) (string, *PrimaryKey, error) {
+	if len(indexName) == 0 {
+		return "", nil, fmt.Errorf("index name is empty")
+	}
+	if !unicode.IsUpper([]rune(indexName)[0]) {
+		return "", nil, fmt.Errorf("index name (%s) must be exported", indexName)
+	}
 	tag := dosaAnnotation
 	// find the primaryKey
 	matchs := indexKeyPattern0.FindStringSubmatch(tag)

--- a/entity_parser_index_test.go
+++ b/entity_parser_index_test.go
@@ -44,6 +44,19 @@ func TestSingleIndexNoParen(t *testing.T) {
 	}, dosaTable.Indexes)
 }
 
+type SingleIndexUnExported struct {
+	Entity       `dosa:"primaryKey=PrimaryKey"`
+	searchByData Index `dosa:"key=Data"`
+	PrimaryKey   int64
+	Data         string
+}
+
+func TestSingleIndexUnExported(t *testing.T) {
+	dosaTable, err := TableFromInstance(&SingleIndexUnExported{})
+	assert.Nil(t, err)
+	assert.Equal(t, map[string]*IndexDefinition{}, dosaTable.Indexes)
+}
+
 type MultipleIndexes struct {
 	Entity       `dosa:"primaryKey=PrimaryKey"`
 	Index        `dosa:"key=Data, name=SearchByData"`

--- a/entity_parser_key_parser_test.go
+++ b/entity_parser_key_parser_test.go
@@ -746,7 +746,7 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "",
-			Error:          errors.New("index name is empty"),
+			Error:          errors.New("invalid name tag"),
 		},
 		{
 			Tag:               "key=((ok))",

--- a/entity_parser_key_parser_test.go
+++ b/entity_parser_key_parser_test.go
@@ -756,7 +756,7 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "searchByKey",
-			Error:          errors.New("index name (searchByKey) must be exported"),
+			Error:          errors.New("index name (searchByKey) must be exported, try (SearchByKey) instead"),
 		},
 	}
 

--- a/entity_parser_key_parser_test.go
+++ b/entity_parser_key_parser_test.go
@@ -735,7 +735,7 @@ func TestIndexParse(t *testing.T) {
 				PartitionKeys:  []string{"ok"},
 				ClusteringKeys: nil,
 			},
-			InputIndexName: "",
+			InputIndexName: "SearchByKey",
 			Error:          nil,
 		},
 		{
@@ -746,7 +746,17 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "",
-			Error:          errors.New("invalid name tag"),
+			Error:          errors.New("index name is empty"),
+		},
+		{
+			Tag:               "key=((ok))",
+			ExpectedIndexName: "",
+			PrimaryKey: &PrimaryKey{
+				PartitionKeys:  []string{"ok"},
+				ClusteringKeys: nil,
+			},
+			InputIndexName: "searchByKey",
+			Error:          errors.New("index name (searchByKey) must be exported"),
 		},
 	}
 

--- a/finder.go
+++ b/finder.go
@@ -36,7 +36,7 @@ import (
 )
 
 // FindEntities finds all entities in the given file paths. An error is
-// returned if there are naming colisions, otherwise, return a slice of
+// returned if there are naming collisions, otherwise, return a slice of
 // warnings (or nil).
 func FindEntities(paths, excludes []string) ([]*Table, []error, error) {
 	var entities []*Table

--- a/finder_test.go
+++ b/finder_test.go
@@ -53,10 +53,10 @@ func TestNonExistentDirectory(t *testing.T) {
 }
 
 func TestParser(t *testing.T) {
-	entities, errs, err := FindEntities([]string{"."}, []string{})
+	entities, _, err := FindEntities([]string{"."}, []string{})
 
-	assert.Equal(t, 19, len(entities), fmt.Sprintf("%s", entities))
-	assert.Equal(t, 20, len(errs), fmt.Sprintf("%v", errs))
+	//assert.Equal(t, 19, len(entities), fmt.Sprintf("%s", entities))
+	//assert.Equal(t, 20, len(errs), fmt.Sprintf("%v", errs))
 	assert.Nil(t, err)
 
 	for _, entity := range entities {

--- a/finder_test.go
+++ b/finder_test.go
@@ -53,58 +53,44 @@ func TestNonExistentDirectory(t *testing.T) {
 }
 
 func TestParser(t *testing.T) {
-	entities, _, err := FindEntities([]string{"."}, []string{})
+	entities, errs, err := FindEntities([]string{"."}, []string{})
+	expectedEntities := map[string]DomainObject{
+		"singleprimarykeynoparen":       &SinglePrimaryKeyNoParen{},
+		"singleprimarykey":              &SinglePrimaryKey{},
+		"singlepartitionkey":            &SinglePartitionKey{},
+		"primarykeywithsecondaryrange":  &PrimaryKeyWithSecondaryRange{},
+		"primarykeywithdescendingrange": &PrimaryKeyWithDescendingRange{},
+		"multicomponentprimarykey":      &MultiComponentPrimaryKey{},
+		"nullabletype":                  &NullableType{},
+		"alltypes":                      &AllTypes{},
+		"unexportedfieldtype":           &UnexportedFieldType{},
+		"ignoretagtype":                 &IgnoreTagType{},
+		"badcolnamebutrenamed":          &BadColNameButRenamed{},
+		"singleindexnoparen":            &SingleIndexNoParen{},
+		"multipleindexes":               &MultipleIndexes{},
+		"complexindexes":                &ComplexIndexes{},
+	}
+	entitiesExcludedForTest := map[string]interface{}{
+		"clienttestentity1":      struct{}{}, // skip, see https://jira.uberinternal.com/browse/DOSA-788
+		"clienttestentity2":      struct{}{}, // skip, same as above
+		"registrytestvalid":      struct{}{}, // skip, same as above
+		"allfieldtypes":          struct{}{},
+		"alltypesscantestentity": struct{}{},
+	}
 
-	//assert.Equal(t, 19, len(entities), fmt.Sprintf("%s", entities))
-	//assert.Equal(t, 20, len(errs), fmt.Sprintf("%v", errs))
+	assert.Equal(t, len(expectedEntities)+len(entitiesExcludedForTest), len(entities), fmt.Sprintf("%s", entities))
+	// TODO(jzhan): remove the hard-coded number of errors.
+	assert.Equal(t, 21, len(errs), fmt.Sprintf("%v", errs))
 	assert.Nil(t, err)
 
 	for _, entity := range entities {
-		var e *Table
-		switch entity.Name {
-		case "singleprimarykeynoparen":
-			e, _ = TableFromInstance(&SinglePrimaryKeyNoParen{})
-		case "singleprimarykey":
-			e, _ = TableFromInstance(&SinglePrimaryKey{})
-		case "singlepartitionkey":
-			e, _ = TableFromInstance(&SinglePartitionKey{})
-		case "primarykeywithsecondaryrange":
-			e, _ = TableFromInstance(&PrimaryKeyWithSecondaryRange{})
-		case "primarykeywithdescendingrange":
-			e, _ = TableFromInstance(&PrimaryKeyWithDescendingRange{})
-		case "multicomponentprimarykey":
-			e, _ = TableFromInstance(&MultiComponentPrimaryKey{})
-		case "nullabletype":
-			e, _ = TableFromInstance(&NullableType{})
-		case "alltypes":
-			e, _ = TableFromInstance(&AllTypes{})
-		case "unexportedfieldtype":
-			e, _ = TableFromInstance(&UnexportedFieldType{})
-		case "ignoretagtype":
-			e, _ = TableFromInstance(&IgnoreTagType{})
-		case "badcolnamebutrenamed":
-			e, _ = TableFromInstance(&BadColNameButRenamed{})
-		case "clienttestentity1": // skip, see https://jira.uberinternal.com/browse/DOSA-788
-			continue
-		case "clienttestentity2": // skip, same as above
-			continue
-		case "registrytestvalid": // skip, same as above
-			continue
-		case "allfieldtypes":
-			continue
-		case "alltypesscantestentity": // skipping test entity defined in scan_test.go
-			continue
-		case "singleindexnoparen":
-			e, _ = TableFromInstance(&SingleIndexNoParen{})
-		case "multipleindexes":
-			e, _ = TableFromInstance(&MultipleIndexes{})
-		case "complexindexes":
-			e, _ = TableFromInstance(&ComplexIndexes{})
-		default:
-			t.Errorf("entity %s not expected", entity.Name)
+		if _, ok := entitiesExcludedForTest[entity.Name]; ok {
 			continue
 		}
-
+		inst, ok := expectedEntities[entity.Name]
+		assert.True(t, ok)
+		e, err := TableFromInstance(inst)
+		assert.NoError(t, err)
 		assert.Equal(t, e, entity)
 	}
 }


### PR DESCRIPTION
When upserting the schema, an unexported index filed will be silently ignored. Adding this validation to error loud to the client.  