### PR TITLE
fix output message in build_cli script

### DIFF
--- a/script/build_cli.sh
+++ b/script/build_cli.sh
@@ -69,7 +69,7 @@ main() {
 
     echo "DONE"
     echo "Darwin package built: ./out/dosa-darwin-${tag}.tar.gz"
-    echo "Linux package built: ./out/dosa-darwin-${tag}.tar.gz"
+    echo "Linux package built: ./out/dosa-linux-${tag}.tar.gz"
 }
 
 main "$@"


### PR DESCRIPTION
There's a small typo in the script for generating the cli. Let's fix it.