### PR TITLE
Add context value to CheckSchema RPC to differentiate requesters, i.e DOSA CLI v.s. DOSA client

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -62,6 +62,8 @@ var (
 	cte1          = &ClientTestEntity1{ID: int64(1), Name: "foo", Email: "foo@uber.com"}
 	cte2          = &ClientTestEntity2{UUID: "b1f23fa3-f453-45b4-a5d5-6d73078ac3bd", Color: "blue", IsActive: true}
 	ctx           = context.TODO()
+	contextClient = context.WithValue(ctx, dosaRenamed.CheckSchemaSource, dosaRenamed.DosaClient)
+	contextCLI    = context.WithValue(ctx, dosaRenamed.CheckSchemaSource, dosaRenamed.DosaCLI)
 	scope         = "test"
 	namePrefix    = "team.service"
 	nullConnector dosaRenamed.Connector
@@ -178,7 +180,7 @@ func TestClient_Initialize(t *testing.T) {
 
 	// CheckSchema error
 	errConn := mocks.NewMockConnector(ctrl)
-	errConn.EXPECT().CheckSchema(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(-1), errors.New("CheckSchema error")).AnyTimes()
+	errConn.EXPECT().CheckSchema(contextClient, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(-1), errors.New("CheckSchema error")).AnyTimes()
 	c2 := dosaRenamed.NewClient(reg, errConn)
 	assert.Error(t, c2.Initialize(ctx))
 
@@ -214,7 +216,7 @@ func TestClient_Read(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockConn := mocks.NewMockConnector(ctrl)
-	mockConn.EXPECT().CheckSchema(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
+	mockConn.EXPECT().CheckSchema(contextClient, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
 	mockConn.EXPECT().Read(ctx, gomock.Any(), gomock.Any(), gomock.Any()).
 		Do(func(_ context.Context, _ *dosaRenamed.EntityInfo, columnValues map[string]dosaRenamed.FieldValue, columnsToRead []string) {
 			assert.Equal(t, columnValues["id"], cte1.ID)
@@ -253,7 +255,7 @@ func TestClient_Read_pointer_result(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockConn := mocks.NewMockConnector(ctrl)
-	mockConn.EXPECT().CheckSchema(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
+	mockConn.EXPECT().CheckSchema(contextClient, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
 	mockConn.EXPECT().Read(ctx, gomock.Any(), gomock.Any(), gomock.Any()).
 		Do(func(_ context.Context, _ *dosaRenamed.EntityInfo, columnValues map[string]dosaRenamed.FieldValue, columnsToRead []string) {
 			assert.Equal(t, columnValues["id"], cte1.ID)
@@ -319,7 +321,7 @@ func TestClient_Read_pointer(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockConn := mocks.NewMockConnector(ctrl)
-	mockConn.EXPECT().CheckSchema(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
+	mockConn.EXPECT().CheckSchema(contextClient, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
 	mockConn.EXPECT().Read(ctx, gomock.Any(), gomock.Any(), gomock.Any()).
 		Do(func(_ context.Context, _ *dosaRenamed.EntityInfo, columnValues map[string]dosaRenamed.FieldValue, columnsToRead []string) {
 			assert.Equal(t, columnValues["id"], allTypes.ID)
@@ -351,7 +353,7 @@ func TestClient_Read_Errors(t *testing.T) {
 	defer ctrl.Finish()
 	readError := errors.New("oops")
 	mockConn := mocks.NewMockConnector(ctrl)
-	mockConn.EXPECT().CheckSchema(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
+	mockConn.EXPECT().CheckSchema(contextClient, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
 	mockConn.EXPECT().Read(ctx, gomock.Any(), gomock.Any(), gomock.Any()).
 		Do(func(_ context.Context, _ *dosaRenamed.EntityInfo, columnValues map[string]dosaRenamed.FieldValue, columnsToRead []string) {
 			assert.Equal(t, columnValues["id"], cte1.ID)
@@ -387,7 +389,7 @@ func TestClient_Upsert(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockConn := mocks.NewMockConnector(ctrl)
-	mockConn.EXPECT().CheckSchema(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
+	mockConn.EXPECT().CheckSchema(contextClient, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
 	mockConn.EXPECT().Upsert(ctx, gomock.Any(), gomock.Any()).
 		Do(func(_ context.Context, _ *dosaRenamed.EntityInfo, columnValues map[string]dosaRenamed.FieldValue) {
 			assert.Equal(t, columnValues["id"], cte1.ID)
@@ -418,7 +420,7 @@ func TestClient_CreateIfNotExists(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockConn := mocks.NewMockConnector(ctrl)
-	mockConn.EXPECT().CheckSchema(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
+	mockConn.EXPECT().CheckSchema(contextClient, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
 	mockConn.EXPECT().CreateIfNotExists(ctx, gomock.Any(), gomock.Any()).
 		Do(func(_ context.Context, _ *dosaRenamed.EntityInfo, columnValues map[string]dosaRenamed.FieldValue) {
 			assert.Equal(t, columnValues["id"], cte1.ID)
@@ -438,7 +440,7 @@ func TestClient_Upsert_Errors(t *testing.T) {
 	defer ctrl.Finish()
 	readError := errors.New("oops")
 	mockConn := mocks.NewMockConnector(ctrl)
-	mockConn.EXPECT().CheckSchema(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
+	mockConn.EXPECT().CheckSchema(contextClient, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
 
 	c1 := dosaRenamed.NewClient(reg1, mockConn)
 	assert.NoError(t, c1.Initialize(ctx))
@@ -482,7 +484,7 @@ func TestClient_RemoveRange(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockConn := mocks.NewMockConnector(ctrl)
-	mockConn.EXPECT().CheckSchema(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
+	mockConn.EXPECT().CheckSchema(contextClient, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
 	mockConn.EXPECT().RemoveRange(ctx, gomock.Any(), gomock.Any()).Return(nil)
 	c2 := dosaRenamed.NewClient(reg1, mockConn)
 	c2.Initialize(ctx)
@@ -533,7 +535,7 @@ func TestClient_Range(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockConn := mocks.NewMockConnector(ctrl)
-	mockConn.EXPECT().CheckSchema(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
+	mockConn.EXPECT().CheckSchema(contextClient, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
 	mockConn.EXPECT().Range(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return([]map[string]dosaRenamed.FieldValue{resultRow}, "continuation-token", nil)
 	c2 := dosaRenamed.NewClient(reg1, mockConn)
@@ -582,7 +584,7 @@ func TestClient_WalkRange(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockConn1 := mocks.NewMockConnector(ctrl)
-	mockConn1.EXPECT().CheckSchema(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
+	mockConn1.EXPECT().CheckSchema(contextClient, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
 	mockConn1.EXPECT().Range(ctx, gomock.Any(), gomock.Any(), gomock.Any(), "", gomock.Any()).
 		Return([]map[string]dosaRenamed.FieldValue{resultRow0}, "token0", nil)
 	mockConn1.EXPECT().Range(ctx, gomock.Any(), gomock.Any(), gomock.Any(), "token0", gomock.Any()).
@@ -608,7 +610,7 @@ func TestClient_WalkRange(t *testing.T) {
 
 	// Range with closure error
 	mockConn2 := mocks.NewMockConnector(ctrl)
-	mockConn2.EXPECT().CheckSchema(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil)
+	mockConn2.EXPECT().CheckSchema(contextClient, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil)
 	mockConn2.EXPECT().Range(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return([]map[string]dosaRenamed.FieldValue{resultRow0}, "", nil)
 	c2 := dosaRenamed.NewClient(reg1, mockConn2)
@@ -655,7 +657,7 @@ func TestClient_ScanEverything(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockConn := mocks.NewMockConnector(ctrl)
-	mockConn.EXPECT().CheckSchema(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
+	mockConn.EXPECT().CheckSchema(contextClient, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
 	mockConn.EXPECT().Scan(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return([]map[string]dosaRenamed.FieldValue{resultRow}, "continuation-token", nil)
 	c2 := dosaRenamed.NewClient(reg1, mockConn)
@@ -696,7 +698,7 @@ func TestClient_Remove(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockConn := mocks.NewMockConnector(ctrl)
-	mockConn.EXPECT().CheckSchema(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
+	mockConn.EXPECT().CheckSchema(contextClient, gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(1), nil).AnyTimes()
 	mockConn.EXPECT().Remove(ctx, gomock.Any(), map[string]dosaRenamed.FieldValue{"id": dosaRenamed.FieldValue(int64(123))}).Return(nil)
 	c2 := dosaRenamed.NewClient(reg1, mockConn)
 	c2.Initialize(ctx)
@@ -800,8 +802,8 @@ type TestEntityB struct {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockConn := mocks.NewMockConnector(ctrl)
-	mockConn.EXPECT().CheckSchema(ctx, scope, "error", gomock.Any()).Return(int32(-1), errors.New("connector error")).Times(1)
-	mockConn.EXPECT().CheckSchema(ctx, scope, namePrefix, gomock.Any()).Return(int32(1), nil).Times(1)
+	mockConn.EXPECT().CheckSchema(contextCLI, scope, "error", gomock.Any()).Return(int32(-1), errors.New("connector error")).Times(1)
+	mockConn.EXPECT().CheckSchema(contextCLI, scope, namePrefix, gomock.Any()).Return(int32(1), nil).Times(1)
 
 	for _, d := range data {
 		_, err := dosaRenamed.NewAdminClient(mockConn).

--- a/connector.go
+++ b/connector.go
@@ -124,8 +124,11 @@ type Connector interface {
 	Scan(ctx context.Context, ei *EntityInfo, minimumFields []string, token string, limit int) (multiValues []map[string]FieldValue, nextToken string, err error)
 
 	// DDL operations (schema)
-	// CheckSchema validates that the set of entities you have provided is valid and registered already
-	// It returns a list of SchemaRef objects for use with later DML operations.
+	// CheckSchema validates the provided entities against the latest applied schema.
+	// Depending on the value set in the context,
+	// - if the requester is DOSA CLI, it checks whether the provided entities are compatible with the latest schema,
+	// - otherwise it checks whether the latest schema is compatible with the provided entities.
+	// It returns the latest schema version for use with later DML operations.
 	CheckSchema(ctx context.Context, scope string, namePrefix string, ed []*EntityDefinition) (version int32, err error)
 	// UpsertSchema updates the schema to match what you provide as entities, if possible
 	UpsertSchema(ctx context.Context, scope string, namePrefix string, ed []*EntityDefinition) (status *SchemaStatus, err error)

--- a/connectors/memory/memory_test.go
+++ b/connectors/memory/memory_test.go
@@ -996,7 +996,7 @@ func TestConnector_RemoveRangeWithSecondaryIndex(t *testing.T) {
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "f1")
-	assert.Contains(t, err.Error(),"partition key")
+	assert.Contains(t, err.Error(), "partition key")
 }
 
 // createTestData populates some test data. The keyGenFunc can either return a constant,

--- a/metrics/noops_test.go
+++ b/metrics/noops_test.go
@@ -21,10 +21,10 @@
 package metrics_test
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/dosa/metrics"
 	"github.com/uber-go/dosa/mocks"
 )

--- a/mocks/client.go
+++ b/mocks/client.go
@@ -25,12 +25,11 @@ package mocks
 
 import (
 	context "context"
-
 	gomock "github.com/golang/mock/gomock"
 	dosa "github.com/uber-go/dosa"
 )
 
-// MockClient is a mock of Client interface
+// Mock of Client interface
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *_MockClientRecorder
@@ -41,19 +40,16 @@ type _MockClientRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &_MockClientRecorder{mock}
 	return mock
 }
 
-// EXPECT adds an expectation
 func (_m *MockClient) EXPECT() *_MockClientRecorder {
 	return _m.recorder
 }
 
-// CreateIfNotExists is a mock implementation of MockClient.CreateIfNotExists
 func (_m *MockClient) CreateIfNotExists(_param0 context.Context, _param1 dosa.DomainObject) error {
 	ret := _m.ctrl.Call(_m, "CreateIfNotExists", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -64,7 +60,6 @@ func (_mr *_MockClientRecorder) CreateIfNotExists(arg0, arg1 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateIfNotExists", arg0, arg1)
 }
 
-// Initialize is a mock implementation of MockClient.Initialize
 func (_m *MockClient) Initialize(_param0 context.Context) error {
 	ret := _m.ctrl.Call(_m, "Initialize", _param0)
 	ret0, _ := ret[0].(error)
@@ -75,7 +70,6 @@ func (_mr *_MockClientRecorder) Initialize(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Initialize", arg0)
 }
 
-// Range is a mock implementation of MockClient.Range
 func (_m *MockClient) Range(_param0 context.Context, _param1 *dosa.RangeOp) ([]dosa.DomainObject, string, error) {
 	ret := _m.ctrl.Call(_m, "Range", _param0, _param1)
 	ret0, _ := ret[0].([]dosa.DomainObject)
@@ -88,7 +82,6 @@ func (_mr *_MockClientRecorder) Range(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Range", arg0, arg1)
 }
 
-// Read is a mock implementation of MockClient.Read
 func (_m *MockClient) Read(_param0 context.Context, _param1 []string, _param2 dosa.DomainObject) error {
 	ret := _m.ctrl.Call(_m, "Read", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
@@ -99,7 +92,6 @@ func (_mr *_MockClientRecorder) Read(arg0, arg1, arg2 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Read", arg0, arg1, arg2)
 }
 
-// Remove is a mock implementation of MockClient.Remove
 func (_m *MockClient) Remove(_param0 context.Context, _param1 dosa.DomainObject) error {
 	ret := _m.ctrl.Call(_m, "Remove", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -110,7 +102,6 @@ func (_mr *_MockClientRecorder) Remove(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Remove", arg0, arg1)
 }
 
-// RemoveRange is a mock implementation of MockClient.RemoveRange
 func (_m *MockClient) RemoveRange(_param0 context.Context, _param1 *dosa.RemoveRangeOp) error {
 	ret := _m.ctrl.Call(_m, "RemoveRange", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -121,7 +112,6 @@ func (_mr *_MockClientRecorder) RemoveRange(arg0, arg1 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveRange", arg0, arg1)
 }
 
-// ScanEverything is a mock implementation of MockClient.ScanEverything
 func (_m *MockClient) ScanEverything(_param0 context.Context, _param1 *dosa.ScanOp) ([]dosa.DomainObject, string, error) {
 	ret := _m.ctrl.Call(_m, "ScanEverything", _param0, _param1)
 	ret0, _ := ret[0].([]dosa.DomainObject)
@@ -134,7 +124,6 @@ func (_mr *_MockClientRecorder) ScanEverything(arg0, arg1 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ScanEverything", arg0, arg1)
 }
 
-// Upsert is a mock implementation of MockClient.Upsert
 func (_m *MockClient) Upsert(_param0 context.Context, _param1 []string, _param2 dosa.DomainObject) error {
 	ret := _m.ctrl.Call(_m, "Upsert", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
@@ -145,7 +134,6 @@ func (_mr *_MockClientRecorder) Upsert(arg0, arg1, arg2 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Upsert", arg0, arg1, arg2)
 }
 
-// WalkRange is a mock implementation of MockClient.WalkRange
 func (_m *MockClient) WalkRange(_param0 context.Context, _param1 *dosa.RangeOp, _param2 func(dosa.DomainObject) error) error {
 	ret := _m.ctrl.Call(_m, "WalkRange", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
@@ -156,7 +144,7 @@ func (_mr *_MockClientRecorder) WalkRange(arg0, arg1, arg2 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WalkRange", arg0, arg1, arg2)
 }
 
-// MockAdminClient is a mock of AdminClient interface
+// Mock of AdminClient interface
 type MockAdminClient struct {
 	ctrl     *gomock.Controller
 	recorder *_MockAdminClientRecorder
@@ -167,19 +155,16 @@ type _MockAdminClientRecorder struct {
 	mock *MockAdminClient
 }
 
-// NewMockAdminClient creates a new mock
 func NewMockAdminClient(ctrl *gomock.Controller) *MockAdminClient {
 	mock := &MockAdminClient{ctrl: ctrl}
 	mock.recorder = &_MockAdminClientRecorder{mock}
 	return mock
 }
 
-// EXPECT adds an expectation
 func (_m *MockAdminClient) EXPECT() *_MockAdminClientRecorder {
 	return _m.recorder
 }
 
-// CheckSchema is a mock implementation of MockAdminClient.CheckSchema
 func (_m *MockAdminClient) CheckSchema(_param0 context.Context, _param1 string) (*dosa.SchemaStatus, error) {
 	ret := _m.ctrl.Call(_m, "CheckSchema", _param0, _param1)
 	ret0, _ := ret[0].(*dosa.SchemaStatus)
@@ -191,7 +176,6 @@ func (_mr *_MockAdminClientRecorder) CheckSchema(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckSchema", arg0, arg1)
 }
 
-// CheckSchemaStatus is a mock implementation of MockAdminClient.CheckSchemaStatus
 func (_m *MockAdminClient) CheckSchemaStatus(_param0 context.Context, _param1 string, _param2 int32) (*dosa.SchemaStatus, error) {
 	ret := _m.ctrl.Call(_m, "CheckSchemaStatus", _param0, _param1, _param2)
 	ret0, _ := ret[0].(*dosa.SchemaStatus)
@@ -203,7 +187,6 @@ func (_mr *_MockAdminClientRecorder) CheckSchemaStatus(arg0, arg1, arg2 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckSchemaStatus", arg0, arg1, arg2)
 }
 
-// CreateScope is a mock implementation of MockAdminClient.CreateScope
 func (_m *MockAdminClient) CreateScope(_param0 context.Context, _param1 string) error {
 	ret := _m.ctrl.Call(_m, "CreateScope", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -214,7 +197,6 @@ func (_mr *_MockAdminClientRecorder) CreateScope(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateScope", arg0, arg1)
 }
 
-// Directories is a mock implementation of MockAdminClient.Directories
 func (_m *MockAdminClient) Directories(_param0 []string) dosa.AdminClient {
 	ret := _m.ctrl.Call(_m, "Directories", _param0)
 	ret0, _ := ret[0].(dosa.AdminClient)
@@ -225,7 +207,6 @@ func (_mr *_MockAdminClientRecorder) Directories(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Directories", arg0)
 }
 
-// DropScope is a mock implementation of MockAdminClient.DropScope
 func (_m *MockAdminClient) DropScope(_param0 context.Context, _param1 string) error {
 	ret := _m.ctrl.Call(_m, "DropScope", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -236,7 +217,6 @@ func (_mr *_MockAdminClientRecorder) DropScope(arg0, arg1 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DropScope", arg0, arg1)
 }
 
-// Excludes is a mock implementation of MockAdminClient.Excludes
 func (_m *MockAdminClient) Excludes(_param0 []string) dosa.AdminClient {
 	ret := _m.ctrl.Call(_m, "Excludes", _param0)
 	ret0, _ := ret[0].(dosa.AdminClient)
@@ -247,7 +227,6 @@ func (_mr *_MockAdminClientRecorder) Excludes(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Excludes", arg0)
 }
 
-// GetSchema is a mock implementation of MockAdminClient.GetSchema
 func (_m *MockAdminClient) GetSchema() ([]*dosa.EntityDefinition, error) {
 	ret := _m.ctrl.Call(_m, "GetSchema")
 	ret0, _ := ret[0].([]*dosa.EntityDefinition)
@@ -259,7 +238,6 @@ func (_mr *_MockAdminClientRecorder) GetSchema() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSchema")
 }
 
-// Scope is a mock implementation of MockAdminClient.Scope
 func (_m *MockAdminClient) Scope(_param0 string) dosa.AdminClient {
 	ret := _m.ctrl.Call(_m, "Scope", _param0)
 	ret0, _ := ret[0].(dosa.AdminClient)
@@ -270,7 +248,6 @@ func (_mr *_MockAdminClientRecorder) Scope(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Scope", arg0)
 }
 
-// TruncateScope is a mock implementation of MockAdminClient.TruncateScope
 func (_m *MockAdminClient) TruncateScope(_param0 context.Context, _param1 string) error {
 	ret := _m.ctrl.Call(_m, "TruncateScope", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -281,7 +258,6 @@ func (_mr *_MockAdminClientRecorder) TruncateScope(arg0, arg1 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TruncateScope", arg0, arg1)
 }
 
-// UpsertSchema is a mock implementation of MockAdminClient.UpsertSchema
 func (_m *MockAdminClient) UpsertSchema(_param0 context.Context, _param1 string) (*dosa.SchemaStatus, error) {
 	ret := _m.ctrl.Call(_m, "UpsertSchema", _param0, _param1)
 	ret0, _ := ret[0].(*dosa.SchemaStatus)

--- a/mocks/connector.go
+++ b/mocks/connector.go
@@ -25,12 +25,11 @@ package mocks
 
 import (
 	context "context"
-
 	gomock "github.com/golang/mock/gomock"
 	dosa "github.com/uber-go/dosa"
 )
 
-// MockConnector is a mock of Connector interface
+// Mock of Connector interface
 type MockConnector struct {
 	ctrl     *gomock.Controller
 	recorder *_MockConnectorRecorder
@@ -41,19 +40,16 @@ type _MockConnectorRecorder struct {
 	mock *MockConnector
 }
 
-// NewMockConnector creates a new mock
 func NewMockConnector(ctrl *gomock.Controller) *MockConnector {
 	mock := &MockConnector{ctrl: ctrl}
 	mock.recorder = &_MockConnectorRecorder{mock}
 	return mock
 }
 
-// EXPECT adds an expectation
 func (_m *MockConnector) EXPECT() *_MockConnectorRecorder {
 	return _m.recorder
 }
 
-// CheckSchema is a mock implementation of MockConnector.CheckSchema
 func (_m *MockConnector) CheckSchema(_param0 context.Context, _param1 string, _param2 string, _param3 []*dosa.EntityDefinition) (int32, error) {
 	ret := _m.ctrl.Call(_m, "CheckSchema", _param0, _param1, _param2, _param3)
 	ret0, _ := ret[0].(int32)
@@ -65,7 +61,6 @@ func (_mr *_MockConnectorRecorder) CheckSchema(arg0, arg1, arg2, arg3 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckSchema", arg0, arg1, arg2, arg3)
 }
 
-// CheckSchemaStatus is a mock implementation of MockConnector.CheckSchemaStatus
 func (_m *MockConnector) CheckSchemaStatus(_param0 context.Context, _param1 string, _param2 string, _param3 int32) (*dosa.SchemaStatus, error) {
 	ret := _m.ctrl.Call(_m, "CheckSchemaStatus", _param0, _param1, _param2, _param3)
 	ret0, _ := ret[0].(*dosa.SchemaStatus)
@@ -77,7 +72,6 @@ func (_mr *_MockConnectorRecorder) CheckSchemaStatus(arg0, arg1, arg2, arg3 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckSchemaStatus", arg0, arg1, arg2, arg3)
 }
 
-// CreateIfNotExists is a mock implementation of MockConnector.CreateIfNotExists
 func (_m *MockConnector) CreateIfNotExists(_param0 context.Context, _param1 *dosa.EntityInfo, _param2 map[string]dosa.FieldValue) error {
 	ret := _m.ctrl.Call(_m, "CreateIfNotExists", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
@@ -88,7 +82,6 @@ func (_mr *_MockConnectorRecorder) CreateIfNotExists(arg0, arg1, arg2 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateIfNotExists", arg0, arg1, arg2)
 }
 
-// CreateScope is a mock implementation of MockConnector.CreateScope
 func (_m *MockConnector) CreateScope(_param0 context.Context, _param1 string) error {
 	ret := _m.ctrl.Call(_m, "CreateScope", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -99,7 +92,6 @@ func (_mr *_MockConnectorRecorder) CreateScope(arg0, arg1 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateScope", arg0, arg1)
 }
 
-// DropScope is a mock implementation of MockConnector.DropScope
 func (_m *MockConnector) DropScope(_param0 context.Context, _param1 string) error {
 	ret := _m.ctrl.Call(_m, "DropScope", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -110,7 +102,6 @@ func (_mr *_MockConnectorRecorder) DropScope(arg0, arg1 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DropScope", arg0, arg1)
 }
 
-// MultiRead is a mock implementation of MockConnector.MultiRead
 func (_m *MockConnector) MultiRead(_param0 context.Context, _param1 *dosa.EntityInfo, _param2 []map[string]dosa.FieldValue, _param3 []string) ([]*dosa.FieldValuesOrError, error) {
 	ret := _m.ctrl.Call(_m, "MultiRead", _param0, _param1, _param2, _param3)
 	ret0, _ := ret[0].([]*dosa.FieldValuesOrError)
@@ -122,7 +113,6 @@ func (_mr *_MockConnectorRecorder) MultiRead(arg0, arg1, arg2, arg3 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MultiRead", arg0, arg1, arg2, arg3)
 }
 
-// MultiRemove is a mock implementation of MockConnector.MultiRemove
 func (_m *MockConnector) MultiRemove(_param0 context.Context, _param1 *dosa.EntityInfo, _param2 []map[string]dosa.FieldValue) ([]error, error) {
 	ret := _m.ctrl.Call(_m, "MultiRemove", _param0, _param1, _param2)
 	ret0, _ := ret[0].([]error)
@@ -134,7 +124,6 @@ func (_mr *_MockConnectorRecorder) MultiRemove(arg0, arg1, arg2 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MultiRemove", arg0, arg1, arg2)
 }
 
-// MultiUpsert is a mock implementation of MockConnector.MultiUpsert
 func (_m *MockConnector) MultiUpsert(_param0 context.Context, _param1 *dosa.EntityInfo, _param2 []map[string]dosa.FieldValue) ([]error, error) {
 	ret := _m.ctrl.Call(_m, "MultiUpsert", _param0, _param1, _param2)
 	ret0, _ := ret[0].([]error)
@@ -146,7 +135,6 @@ func (_mr *_MockConnectorRecorder) MultiUpsert(arg0, arg1, arg2 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MultiUpsert", arg0, arg1, arg2)
 }
 
-// Range is a mock implementation of MockConnector.Range
 func (_m *MockConnector) Range(_param0 context.Context, _param1 *dosa.EntityInfo, _param2 map[string][]*dosa.Condition, _param3 []string, _param4 string, _param5 int) ([]map[string]dosa.FieldValue, string, error) {
 	ret := _m.ctrl.Call(_m, "Range", _param0, _param1, _param2, _param3, _param4, _param5)
 	ret0, _ := ret[0].([]map[string]dosa.FieldValue)
@@ -159,7 +147,6 @@ func (_mr *_MockConnectorRecorder) Range(arg0, arg1, arg2, arg3, arg4, arg5 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Range", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-// Read is a mock implementation of MockConnector.Read
 func (_m *MockConnector) Read(_param0 context.Context, _param1 *dosa.EntityInfo, _param2 map[string]dosa.FieldValue, _param3 []string) (map[string]dosa.FieldValue, error) {
 	ret := _m.ctrl.Call(_m, "Read", _param0, _param1, _param2, _param3)
 	ret0, _ := ret[0].(map[string]dosa.FieldValue)
@@ -171,7 +158,6 @@ func (_mr *_MockConnectorRecorder) Read(arg0, arg1, arg2, arg3 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Read", arg0, arg1, arg2, arg3)
 }
 
-// Remove is a mock implementation of MockConnector.Remove
 func (_m *MockConnector) Remove(_param0 context.Context, _param1 *dosa.EntityInfo, _param2 map[string]dosa.FieldValue) error {
 	ret := _m.ctrl.Call(_m, "Remove", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
@@ -182,7 +168,6 @@ func (_mr *_MockConnectorRecorder) Remove(arg0, arg1, arg2 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Remove", arg0, arg1, arg2)
 }
 
-// RemoveRange is a mock implementation of MockConnector.RemoveRange
 func (_m *MockConnector) RemoveRange(_param0 context.Context, _param1 *dosa.EntityInfo, _param2 map[string][]*dosa.Condition) error {
 	ret := _m.ctrl.Call(_m, "RemoveRange", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
@@ -193,7 +178,6 @@ func (_mr *_MockConnectorRecorder) RemoveRange(arg0, arg1, arg2 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveRange", arg0, arg1, arg2)
 }
 
-// Scan is a mock implementation of MockConnector.Scan
 func (_m *MockConnector) Scan(_param0 context.Context, _param1 *dosa.EntityInfo, _param2 []string, _param3 string, _param4 int) ([]map[string]dosa.FieldValue, string, error) {
 	ret := _m.ctrl.Call(_m, "Scan", _param0, _param1, _param2, _param3, _param4)
 	ret0, _ := ret[0].([]map[string]dosa.FieldValue)
@@ -206,7 +190,6 @@ func (_mr *_MockConnectorRecorder) Scan(arg0, arg1, arg2, arg3, arg4 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Scan", arg0, arg1, arg2, arg3, arg4)
 }
 
-// ScopeExists is a mock implementation of MockConnector.ScopeExists
 func (_m *MockConnector) ScopeExists(_param0 context.Context, _param1 string) (bool, error) {
 	ret := _m.ctrl.Call(_m, "ScopeExists", _param0, _param1)
 	ret0, _ := ret[0].(bool)
@@ -218,7 +201,6 @@ func (_mr *_MockConnectorRecorder) ScopeExists(arg0, arg1 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ScopeExists", arg0, arg1)
 }
 
-// Shutdown is a mock implementation of MockConnector.Shutdown
 func (_m *MockConnector) Shutdown() error {
 	ret := _m.ctrl.Call(_m, "Shutdown")
 	ret0, _ := ret[0].(error)
@@ -229,7 +211,6 @@ func (_mr *_MockConnectorRecorder) Shutdown() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Shutdown")
 }
 
-// TruncateScope is a mock implementation of MockConnector.TruncateScope
 func (_m *MockConnector) TruncateScope(_param0 context.Context, _param1 string) error {
 	ret := _m.ctrl.Call(_m, "TruncateScope", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -240,7 +221,6 @@ func (_mr *_MockConnectorRecorder) TruncateScope(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TruncateScope", arg0, arg1)
 }
 
-// Upsert is a mock implementation of MockConnector.Upsert
 func (_m *MockConnector) Upsert(_param0 context.Context, _param1 *dosa.EntityInfo, _param2 map[string]dosa.FieldValue) error {
 	ret := _m.ctrl.Call(_m, "Upsert", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
@@ -251,7 +231,6 @@ func (_mr *_MockConnectorRecorder) Upsert(arg0, arg1, arg2 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Upsert", arg0, arg1, arg2)
 }
 
-// UpsertSchema is a mock implementation of MockConnector.UpsertSchema
 func (_m *MockConnector) UpsertSchema(_param0 context.Context, _param1 string, _param2 string, _param3 []*dosa.EntityDefinition) (*dosa.SchemaStatus, error) {
 	ret := _m.ctrl.Call(_m, "UpsertSchema", _param0, _param1, _param2, _param3)
 	ret0, _ := ret[0].(*dosa.SchemaStatus)


### PR DESCRIPTION
CheckSchema RPC is used in two different cases:

1. in DOSA CLI, to validate whether a new entity can be upserted (i.e. the new entity is compatible with the latest schema)
2. during client initialization, to verify whether the client provide entity are valid and have been already registered. (i.e. the latest schema is compatible with the provided entity)

Here we simply pass the requester information in the context so that DOSA gateway can behave accordingly. 
