### PR TITLE
Make scope name required in CLI schema commands

### DIFF
--- a/cmd/dosa/main_test.go
+++ b/cmd/dosa/main_test.go
@@ -57,7 +57,7 @@ func TestHostOptionButNothingElse(t *testing.T) {
 func TestInvalidHost(t *testing.T) {
 	c := StartCapture()
 	exit = func(r int) {}
-	os.Args = []string{"dosa", "--host", "invalid-hostname.", "schema", "check", "--prefix", "foo", "../../testentity"}
+	os.Args = []string{"dosa", "--host", "invalid-hostname.", "schema", "check", "--scope", "bar", "--prefix", "foo", "../../testentity"}
 	main()
 	output := c.stop(true)
 	assert.Contains(t, output, "invalid-hostname")
@@ -69,7 +69,7 @@ func TestInvalidHost(t *testing.T) {
 func TestInvalidPort(t *testing.T) {
 	c := StartCapture()
 	exit = func(r int) {}
-	os.Args = []string{"dosa", "-p", "invalid-port", "schema", "check", "--prefix", "foo", "../../testentity"}
+	os.Args = []string{"dosa", "-p", "invalid-port", "schema", "check", "--scope", "bar", "--prefix", "foo", "../../testentity"}
 	main()
 	output := c.stop(true)
 	assert.Contains(t, output, "invalid-port")
@@ -80,7 +80,7 @@ func TestInvalidPort(t *testing.T) {
 func TestInvalidTransport(t *testing.T) {
 	c := StartCapture()
 	exit = func(r int) {}
-	os.Args = []string{"dosa", "--transport", "invalid-transport", "schema", "check", "--prefix", "foo", "../../testentity"}
+	os.Args = []string{"dosa", "--transport", "invalid-transport", "schema", "check", "--scope", "bar", "--prefix", "foo", "../../testentity"}
 	main()
 	output := c.stop(true)
 	assert.Contains(t, output, "invalid transport")

--- a/cmd/dosa/schema.go
+++ b/cmd/dosa/schema.go
@@ -68,7 +68,7 @@ type SchemaOptions struct {
 // SchemaCmd is a placeholder for all schema commands
 type SchemaCmd struct {
 	*SchemaOptions
-	Scope      scopeFlag `short:"s" long:"scope" description:"Storage scope for the given operation."`
+	Scope      scopeFlag `short:"s" long:"scope" description:"Storage scope for the given operation." required:"true"`
 	NamePrefix string    `long:"prefix" description:"Name prefix for schema types." required:"true"`
 }
 

--- a/cmd/dosa/schema_test.go
+++ b/cmd/dosa/schema_test.go
@@ -144,6 +144,22 @@ func TestSchema_Defaults(t *testing.T) {
 	}
 }
 
+func TestSchema_ScopeRequired(t *testing.T) {
+	for _, cmd := range []string{"check", "upsert"} {
+		c := StartCapture()
+		exit = func(r int) {}
+		os.Args = []string{
+			"dosa",
+			"schema",
+			cmd,
+			"--prefix", "foo",
+			"../../testentity",
+		}
+		main()
+		assert.Contains(t, c.stop(true), "-s, --scope' was not specified")
+	}
+}
+
 func TestSchema_PrefixRequired(t *testing.T) {
 	for _, cmd := range []string{"check", "upsert"} {
 		c := StartCapture()

--- a/cmd/dosa/schema_test.go
+++ b/cmd/dosa/schema_test.go
@@ -168,6 +168,7 @@ func TestSchema_PrefixRequired(t *testing.T) {
 			"dosa",
 			"schema",
 			cmd,
+			"--scope", "foo",
 			"../../testentity",
 		}
 		main()
@@ -191,7 +192,7 @@ func TestSchema_InvalidDirectory(t *testing.T) {
 			cmd,
 		}
 		if hasPrefix {
-			os.Args = append(os.Args, "--prefix", "foo")
+			os.Args = append(os.Args, "--scope", "bar", "--prefix", "foo")
 		}
 		os.Args = append(os.Args, []string{
 			"-e", "testentity.go",
@@ -219,7 +220,7 @@ func TestSchema_NoEntitiesFound(t *testing.T) {
 			cmd,
 		}
 		if hasPrefix {
-			os.Args = append(os.Args, "--prefix", "foo")
+			os.Args = append(os.Args, "--scope", "bar", "--prefix", "foo")
 		}
 		os.Args = append(os.Args, []string{
 			"-e", "testentity.go",

--- a/connectors/memory/memory_test.go
+++ b/connectors/memory/memory_test.go
@@ -996,7 +996,7 @@ func TestConnector_RemoveRangeWithSecondaryIndex(t *testing.T) {
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "f1")
-	assert.Contains(t, err.Error(),"partition key")
+	assert.Contains(t, err.Error(), "partition key")
 }
 
 // createTestData populates some test data. The keyGenFunc can either return a constant,

--- a/metrics/noops_test.go
+++ b/metrics/noops_test.go
@@ -21,10 +21,10 @@
 package metrics_test
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/dosa/metrics"
 	"github.com/uber-go/dosa/mocks"
 )


### PR DESCRIPTION
Make scope name required for CLI schema command, i.e. check, upsert, and status.

Currently it defaults to the username which can easily cause confusions and mistakes. By make CLI users to explicitly specify scope name, it's less error-prone:
-  it prevents users from accidentally accessing/modifying schema on unintended scopes
-  it avoids ambiguous error messages due to using the wrong scope name. 
