### PR TITLE
Upsert to fallback only on successes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v2.6.0 (unreleased)
 - Add encoding package which contains basic implementations of json and gob encoding
+- Fallback connector fixes, including always return all results as pointers and only writing to fallback when origin succeeds 
 
 ## v2.5.0 (unreleased)
 

--- a/connectors/cache/fallback.go
+++ b/connectors/cache/fallback.go
@@ -99,11 +99,12 @@ func (c *Connector) Upsert(ctx context.Context, ei *dosa.EntityInfo, values map[
 		}
 		return c.fallback.Upsert(newCtx, adaptedEi, newValues)
 	}
-	if c.isCacheable(ei) {
+
+	originalErr := c.Next.Upsert(ctx, ei, values)
+	if originalErr == nil && c.isCacheable(ei) {
 		_ = c.cacheWrite(w)
 	}
-
-	return c.Next.Upsert(ctx, ei, values)
+	return originalErr
 }
 
 func (c *Connector) Read(ctx context.Context, ei *dosa.EntityInfo, keys map[string]dosa.FieldValue, minimumFields []string) (values map[string]dosa.FieldValue, err error) {


### PR DESCRIPTION
Previously we would upsert to both dosa and the cache in parallel in goroutines. However, this has the weird behavior where the dosa path might fail but the cache call succeeds so the data will be found in cache but not in dosa. We should not have this inconsistent behavior and wait to see if the dosa call succeeds. 