### PR TITLE
expose the IsDomainObject API

### DIFF
--- a/client.go
+++ b/client.go
@@ -104,6 +104,9 @@ func ErrorIsAlreadyExists(err error) bool {
 
 // Client defines the methods to operate with DOSA entities
 type Client interface {
+	// GetRegistrar returns the registrar
+	GetRegistrar() Registrar
+
 	// Initialize must be called before any data operation
 	Initialize(ctx context.Context) error
 
@@ -229,6 +232,11 @@ func NewClient(reg Registrar, conn Connector) Client {
 		registrar: reg,
 		connector: conn,
 	}
+}
+
+// GetRegistrar returns the registrar that is registered in the client
+func (c *client) GetRegistrar() Registrar {
+	return c.registrar
 }
 
 // Initialize performs initial schema checks against all registered entities.

--- a/connectors/cache/fallback_test.go
+++ b/connectors/cache/fallback_test.go
@@ -146,9 +146,9 @@ func TestUpsertCases(t *testing.T) {
 				}},
 		},
 		{
-			description: "Unsuccessful origin upsert does not upsert to fallback",
+			description:  "Unsuccessful origin upsert does not upsert to fallback",
 			originUpsert: &expectArgs{err: assert.AnError},
-			expectedErr: assert.AnError,
+			expectedErr:  assert.AnError,
 		},
 	}
 	for _, t := range testCases {

--- a/connectors/memory/memory.go
+++ b/connectors/memory/memory.go
@@ -299,7 +299,7 @@ func (c *Connector) MultiRead(ctx context.Context, ei *dosa.EntityInfo, values [
 		fieldValue, err := c.Read(ctx, ei, v, minimumFields)
 		fvoe := &dosa.FieldValuesOrError{}
 		if err != nil {
-			 fvoe.Error = err
+			fvoe.Error = err
 		} else {
 			fvoe.Values = fieldValue
 		}

--- a/mocks/client.go
+++ b/mocks/client.go
@@ -61,6 +61,16 @@ func (_mr *_MockClientRecorder) CreateIfNotExists(arg0, arg1 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateIfNotExists", arg0, arg1)
 }
 
+func (_m *MockClient) GetRegistrar() dosa.Registrar {
+	ret := _m.ctrl.Call(_m, "GetRegistrar")
+	ret0, _ := ret[0].(dosa.Registrar)
+	return ret0
+}
+
+func (_mr *_MockClientRecorder) GetRegistrar() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetRegistrar")
+}
+
 func (_m *MockClient) Initialize(_param0 context.Context) error {
 	ret := _m.ctrl.Call(_m, "Initialize", _param0)
 	ret0, _ := ret[0].(error)


### PR DESCRIPTION
Users want to have someway to tell whether a object is registered as DOSA object. Registrar has `find` method so that users can tell if an domainObject is registered or not.