### PR TITLE
Fix Compound Partition Keys in In-Memory Connector

### DIFF
--- a/connectors/memory/memory.go
+++ b/connectors/memory/memory.go
@@ -90,7 +90,8 @@ func partitionKeyBuilder(pk *dosa.PrimaryKey, values map[string]dosa.FieldValue)
 	var encodedKey []byte
 	for _, k := range pk.PartitionKeys {
 		if v, ok := values[k]; ok {
-			encodedKey, _ = encoder.Encode(v)
+			encodedVal, _ := encoder.Encode(v)
+			encodedKey = append(encodedKey, encodedVal...)
 		} else {
 			return "", errors.Errorf("Missing value for partition key %q", k)
 		}
@@ -386,7 +387,7 @@ func (c *Connector) Remove(_ context.Context, ei *dosa.EntityInfo, values map[st
 			c.removeItem(iName, ei.Def.UniqueKey(iDef.Key), removedValues)
 		}
 	}
-		return nil
+	return nil
 }
 
 func (c *Connector) removeItem(name string, key *dosa.PrimaryKey, values map[string]dosa.FieldValue) map[string]dosa.FieldValue {

--- a/connectors/memory/memory_test.go
+++ b/connectors/memory/memory_test.go
@@ -1129,7 +1129,6 @@ func TestCompoundPartSecondaryIndex(t *testing.T) {
 	sut := NewConnector()
 	bucketID := 1
 	now := time.Now()
-	fourHoursAgo := now.Add(-4 * time.Hour)
 
 	repoUUID0 := uuid.NewV4().String()
 	createdAt0 := now.Add(-1 * time.Hour)

--- a/connectors/memory/memory_test.go
+++ b/connectors/memory/memory_test.go
@@ -41,6 +41,22 @@ var testSchemaRef = dosa.SchemaRef{
 	Version:    12345,
 }
 
+var compoundPartEi = &dosa.EntityInfo{
+	Ref: &testSchemaRef,
+	Def: &dosa.EntityDefinition{
+		Columns: []*dosa.ColumnDefinition{
+			{Name: "RepositoryUUID", Type: dosa.TUUID},
+			{Name: "BucketID", Type: dosa.Int32},
+			{Name: "CreatedAt", Type: dosa.Timestamp},
+			{Name: "Result", Type: dosa.Int32},
+		},
+		Key: &dosa.PrimaryKey{
+			PartitionKeys: []string{"RepositoryUUID", "BucketID"},
+		},
+		Name: "compoundPartTable",
+	},
+}
+
 var testEi = &dosa.EntityInfo{
 	Ref: &testSchemaRef,
 	Def: &dosa.EntityDefinition{
@@ -1107,6 +1123,55 @@ func TestConnector_RemoveRangeWithSecondaryIndex(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "f1")
 	assert.Contains(t, err.Error(), "partition key")
+}
+
+func TestCompoundPartSecondaryIndex(t *testing.T) {
+	sut := NewConnector()
+	bucketID := 1
+	now := time.Now()
+	fourHoursAgo := now.Add(-4 * time.Hour)
+
+	repoUUID0 := uuid.NewV4().String()
+	createdAt0 := now.Add(-1 * time.Hour)
+	result0 := 5
+
+	err := sut.Upsert(context.TODO(), compoundPartEi, map[string]dosa.FieldValue{
+		"RepositoryUUID": dosa.FieldValue(dosa.UUID(repoUUID0)),
+		"BucketID":       dosa.FieldValue(int32(bucketID)),
+		"CreatedAt":      dosa.FieldValue(createdAt0),
+		"Result":         dosa.FieldValue(int32(result0)),
+	})
+
+	repoUUID1 := uuid.NewV4().String()
+	createdAt1 := now.Add(-2 * time.Hour)
+	result1 := 4
+
+	err = sut.Upsert(context.TODO(), compoundPartEi, map[string]dosa.FieldValue{
+		"RepositoryUUID": dosa.FieldValue(dosa.UUID(repoUUID1)),
+		"BucketID":       dosa.FieldValue(int32(bucketID)),
+		"CreatedAt":      dosa.FieldValue(createdAt1),
+		"Result":         dosa.FieldValue(int32(result1)),
+	})
+
+	assert.NoError(t, err)
+
+	pk0 := map[string]dosa.FieldValue{
+		"RepositoryUUID": dosa.FieldValue(dosa.UUID(repoUUID0)),
+		"BucketID":       dosa.FieldValue(int32(bucketID)),
+	}
+	readVals0, err := sut.Read(context.TODO(), compoundPartEi, pk0, dosa.All())
+	assert.NoError(t, err)
+	assert.Equal(t, readVals0["Result"], int32(result0))
+	assert.Equal(t, readVals0["CreatedAt"], createdAt0)
+
+	pk1 := map[string]dosa.FieldValue{
+		"RepositoryUUID": dosa.FieldValue(dosa.UUID(repoUUID1)),
+		"BucketID":       dosa.FieldValue(int32(bucketID)),
+	}
+	readVals1, err := sut.Read(context.TODO(), compoundPartEi, pk1, dosa.All())
+	assert.NoError(t, err)
+	assert.Equal(t, readVals1["Result"], int32(result1))
+	assert.EqualValues(t, readVals1["CreatedAt"], createdAt1)
 }
 
 // createTestData populates some test data. The keyGenFunc can either return a constant,


### PR DESCRIPTION
Compound Partition Keys are completely broken with the in-memory connector. Each time a value of a partition key is encoded in `partitionKeyBuilder` the previous encoded partition key value is completely overwritten. This means for entities that have more than one column as part of their partition key, only the last partition key value is used when creating the encoded partition key value.

The result of this is that if two rows have the same value for the last column that's part of their partition key (but different values for the other columns making up their partition key), the second row will completely overwrite the first (since the resulting encoded partition key is the same for both rows).

Let's fix this by concating all of the encoded values for each partition key column and using the result as the encoded partition key.

Let's also write a test that proves compound partition keys now work.