### PR TITLE
fix bad race conditions in memory connector

### DIFF
--- a/connectors/memory/memory.go
+++ b/connectors/memory/memory.go
@@ -134,7 +134,7 @@ func compareRows(pk *dosa.PrimaryKey, v1 map[string]dosa.FieldValue, v2 map[stri
 }
 
 // copyRows copies all the rows in the given slice and returns a new slice with copies
-// of each of the copies. Order is maintained.
+// of each row. Order is maintained.
 func copyRows(rows []map[string]dosa.FieldValue) []map[string]dosa.FieldValue {
 	copied := make([]map[string]dosa.FieldValue, len(rows))
 	for i, row := range rows {


### PR DESCRIPTION
Currently, when reading, ranging, or scanning from the in-memory connector, the connector returns references to internal data (in the forms of slices and maps). This allows callers to read/write internal data without acquiring the appropriate locks inside the in-memory connector, resulting in race conditions.

By returning copies of the values stored within the in-memory connector, we can ensure the values returned to the caller have no references to the internal state within the in-memory connector and prevent data races.