### PR TITLE
Prepare 2.5.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
 ## v2.6.0 (unreleased)
+
+## v2.5.3 (unreleased)
 - Invalidate fallback cache on upsert (#285)
+- Properly Interpret NotFound errors for MultiRead in the YARPC connector (#287)
 
 ## v2.5.2 (2018-02-05)
 - Fix memory connector bug with compound partition keys (#281)

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package dosa
 
 // VERSION indicates the dosa client version
-const VERSION = "2.5.2"
+const VERSION = "2.5.3"


### PR DESCRIPTION
This PR does all of the necessary steps for preparing a release of dosa version 2.5.3. Namely, it updates the version number in `version.go` and brings the `CHANGELOG.md` file up to date.