### PR TITLE
Return single value from func NewUUID

### DIFF
--- a/type.go
+++ b/type.go
@@ -66,7 +66,8 @@ type UUID string
 
 // NewUUID is a helper for returning a new dosa.UUID value
 func NewUUID() UUID {
-	return UUID(uuid.NewV4().String())
+	value, _ := uuid.NewV4()
+	return UUID(value.String())
 }
 
 // Bytes gets the bytes from a UUID


### PR DESCRIPTION
When I tried to download the DOSA CLI via `go get -u github.com/uber-go/dosa/cmd/dosa` I saw the following error:

```
# github.com/uber-go/dosa
../../../github.com/uber-go/dosa/type.go:69:24: multiple-value uuid.NewV4() in single-value context
```

This PR provides the bug fix.