### PR TITLE
Implement multi upsert and multi remove methods in memory connector

### DIFF
--- a/connectors/memory/memory.go
+++ b/connectors/memory/memory.go
@@ -334,6 +334,28 @@ func (c *Connector) MultiRead(ctx context.Context, ei *dosa.EntityInfo, values [
 	return fvoes, nil
 }
 
+// MultiUpsert upserts a series of values at once.
+func (c *Connector) MultiUpsert(ctx context.Context, ei *dosa.EntityInfo, values []map[string]dosa.FieldValue) ([]error, error) {
+	// Note we do not lock here. This is representative of the behavior one would see in a deployed environment
+	var errs []error
+	for _, v := range values {
+		errs = append(errs, c.Upsert(ctx, ei, v))
+	}
+
+	return errs, nil
+}
+
+// MultiRemove removes a series of values at once.
+func (c *Connector) MultiRemove(ctx context.Context, ei *dosa.EntityInfo, multiValues []map[string]dosa.FieldValue) ([]error, error) {
+	// Note we do not lock here. This is representative of the behavior one would see in a deployed environment
+	var errs []error
+	for _, v := range multiValues {
+		errs = append(errs, c.Remove(ctx, ei, v))
+	}
+
+	return errs, nil
+}
+
 func overwriteValuesFunc(into map[string]dosa.FieldValue, from map[string]dosa.FieldValue) error {
 	for k, v := range from {
 		into[k] = v


### PR DESCRIPTION
This implements the missing multi upsert and multi remove methods in the memory connector. As noted, this does not use a lock when removing and upserting the set of entities. There is no such guarantee provided in the interface and thus we do not do it here.