### PR TITLE
add ability to indicate bad args

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -28,6 +28,30 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ErrBadArgs allows connectors to indicate to their upstreams
+// that something about the args they recieved for a particular operation
+// are not valid.
+type ErrBadArgs struct {
+	msg string
+}
+
+func NewErrBadArgs(msg string) error {
+	return &ErrBadArgs{
+		msg: msg,
+	}
+}
+
+// Error returns the error message for an ErrBadArgs error.
+func (e *ErrBadArgs) Error() string {
+	return e.msg
+}
+
+// ErrorIsBadArgs checks if the error is an "ErrBadArgs".
+func ErrorIsBadArgs(err error) bool {
+	_, ok := errors.Cause(err).(*ErrBadArgs)
+	return ok
+}
+
 //go:generate stringer -type=Operator
 
 // Operator defines an operator against some data for range scans

--- a/connector_test.go
+++ b/connector_test.go
@@ -1,0 +1,16 @@
+package dosa
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorIsBadArgs(t *testing.T) {
+	badArgsErr := NewErrBadArgs("you can't use that!")
+	assert.True(t, ErrorIsBadArgs(badArgsErr))
+
+	regErr := errors.New("hello")
+	assert.False(t, ErrorIsBadArgs(regErr))
+}


### PR DESCRIPTION
There are instances where we'd like to be able to indicate to upstream connectors that the particular args they received were invalid (i.e. the request was incorrect). Having this error would allow us, for instance, to catch Cassandra specific errors and bubble them up to the yarpc connector, which could then in turn properly encapsulate the error as a `BadRequestError` instead of an internal service error.