### PR TITLE
Use Satori UUID and bump it to 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ install:
   - ./setup.py install --user
   - popd
   - go get github.com/golang/mock/mockgen
+  - go get golang.org/x/lint
 
 script:
   - make lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ cache:
     - vendor
 
 install:
+  - go get golang.org/x/lint
   - make vendor
   - pip install --user cql PyYAML six
   - git clone --depth 1 https://github.com/pcmanus/ccm.git
@@ -26,7 +27,6 @@ install:
   - ./setup.py install --user
   - popd
   - go get github.com/golang/mock/mockgen
-  - go get golang.org/x/lint
 
 script:
   - make lint

--- a/client_test.go
+++ b/client_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
+	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 
 	"fmt"
@@ -278,14 +279,14 @@ type AllFieldTypes struct {
 	StringType         string
 	BlobType           []byte
 	TimeType           time.Time
-	UUIDType           dosaRenamed.UUID
+	UUIDType           uuid.UUID
 	NullBoolType       *bool
 	NullInt32Type      *int32
 	NullInt64Type      *int64
 	NullDoubleType     *float64
 	NullStringType     *string
 	NullTimeType       *time.Time
-	NullUUIDType       *dosaRenamed.UUID
+	NullUUIDType       *uuid.UUID
 }
 
 func TestClient_Read_pointer(t *testing.T) {
@@ -301,14 +302,14 @@ func TestClient_Read_pointer(t *testing.T) {
 		"stringtype":     "faa@email.com",
 		"blobtype":       []byte("hello world"),
 		"timetype":       time.Now(),
-		"uuidtype":       dosaRenamed.NewUUID(),
+		"uuidtype":       uuid.NewV4(),
 		"nullbooltype":   testutil.TestBoolPtr(true),
 		"nullint32type":  testutil.TestInt32Ptr(int32(123)),
 		"nullint64type":  testutil.TestInt64Ptr(int64(2)),
 		"nulldoubletype": testutil.TestFloat64Ptr(float64(8.9)),
 		"nullstringtype": testutil.TestStringPtr("bar@email.com"),
 		"nulltimetype":   testutil.TestTimePtr(time.Now()),
-		"nulluuidtype":   testutil.TestUUIDPtr(dosaRenamed.NewUUID()),
+		"nulluuidtype":   testutil.TestUUIDPtr(uuid.NewV4()),
 	}
 
 	// uninitialized

--- a/connectors/cache/fallback.go
+++ b/connectors/cache/fallback.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/satori/go.uuid"
 	"github.com/uber-go/dosa"
 	"github.com/uber-go/dosa/connectors/base"
 	"github.com/uber-go/dosa/encoding"
@@ -471,7 +472,7 @@ func rawRowAsPointers(ei *dosa.EntityInfo, values map[string]dosa.FieldValue) ma
 				// do nothing with byte arrays
 				convertedValues[colName] = val
 			case dosa.TUUID:
-				if u, ok := val.(dosa.UUID); ok {
+				if u, ok := val.(uuid.UUID); ok {
 					convertedValues[colName] = &u
 				}
 			case dosa.String:

--- a/connectors/cache/fallback_test.go
+++ b/connectors/cache/fallback_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/dosa"
 	"github.com/uber-go/dosa/connectors/memory"
@@ -1000,7 +1001,7 @@ func TestFallbackEndToEnd(t *testing.T) {
 	}
 	redisC := redis.NewConnector(testRedisConfig, nil)
 
-	testUUID := dosa.UUID("d1449c93-25b8-4032-920b-60471d91acc9")
+	testUUID, _ := uuid.FromString("d1449c93-25b8-4032-920b-60471d91acc9")
 	testStr := "test string"
 	testStr2 := "another test string"
 	testInt64 := int64(29385235)

--- a/connectors/cassandra/cassandra_test.go
+++ b/connectors/cassandra/cassandra_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/gocql/gocql"
+	"github.com/satori/go.uuid"
 	"github.com/uber-go/dosa"
 	"github.com/uber-go/dosa/connectors/cassandra"
 	_ "github.com/uber-go/dosa/connectors/cassandra"
@@ -58,8 +59,9 @@ func TestNewConnector(t *testing.T) {
 	}
 	sr := dosa.SchemaRef{Scope: "example", NamePrefix: "example"}
 
+	u1, _ := uuid.FromString("c778ba9e-a241-471c-9b5b-4b4c1ef1c5b7")
 	err = c.Upsert(ctx, &dosa.EntityInfo{Ref: &sr, Def: &ei.EntityDefinition}, map[string]dosa.FieldValue{
-		"an_uuid_key": dosa.UUID("c778ba9e-a241-471c-9b5b-4b4c1ef1c5b7"),
+		"an_uuid_key": u1,
 		"strkey":      "test",
 		"int64key":    int64(11),
 	})

--- a/connectors/cassandra/datastore_crud.go
+++ b/connectors/cassandra/datastore_crud.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gocql/gocql"
 	"github.com/pkg/errors"
+	"github.com/satori/go.uuid"
 	"github.com/uber-go/dosa"
 )
 
@@ -43,6 +44,14 @@ func sortFieldValue(obj map[string]dosa.FieldValue) ([]string, []interface{}, er
 	values := make([]interface{}, len(obj))
 	for pos, c := range columns {
 		values[pos] = obj[c]
+		var err error
+		// UUIDs are converted between satori and gocql via string; errors are not expected.
+		if u, ok := obj[c].(uuid.UUID); ok {
+			values[pos], err = gocql.ParseUUID(u.String())
+			if err != nil {
+				return nil, nil, errors.Wrapf(err, "invalid uuid %s", u)
+			}
+		}
 	}
 
 	return columns, values, nil
@@ -134,7 +143,7 @@ func (c *Connector) Read(ctx context.Context, ei *dosa.EntityInfo, keys map[stri
 		return nil, errors.Wrapf(err, "failed to execute read query in Cassandra: %s", stmt)
 	}
 
-	return convertToDOSATypes(ei, result), nil
+	return convertToDOSATypes(ei, result)
 }
 
 // Upsert means update an existing object or create a new object
@@ -207,7 +216,8 @@ func (c *Connector) remove(ctx context.Context, ei *dosa.EntityInfo, conds []*do
 	return nil
 }
 
-func convertToDOSATypes(ei *dosa.EntityInfo, row map[string]interface{}) map[string]dosa.FieldValue {
+func convertToDOSATypes(ei *dosa.EntityInfo, row map[string]interface{}) (map[string]dosa.FieldValue, error) {
+	var err error
 	res := make(map[string]dosa.FieldValue)
 	ct := extractColumnTypes(ei)
 	for k, v := range row {
@@ -215,6 +225,11 @@ func convertToDOSATypes(ei *dosa.EntityInfo, row map[string]interface{}) map[str
 		raw := v
 		// special handling
 		switch dosaType {
+		case dosa.TUUID:
+			uuidStr := raw.(gocql.UUID).String()
+			if raw, err = uuid.FromString(uuidStr); err != nil {
+				return nil, errors.Wrapf(err, "incompatible UUID %s", uuidStr)
+			}
 		// for whatever reason, gocql returns int for int32 field
 		// TODO: decide whether to store timestamp as int64 for better resolution; see
 		// https://code.uberinternal.com/T733022
@@ -223,7 +238,7 @@ func convertToDOSATypes(ei *dosa.EntityInfo, row map[string]interface{}) map[str
 		}
 		res[k] = raw
 	}
-	return res
+	return res, nil
 }
 
 func extractColumnTypes(ei *dosa.EntityInfo) map[string]dosa.Type {

--- a/connectors/cassandra/datastore_crud.go
+++ b/connectors/cassandra/datastore_crud.go
@@ -43,14 +43,6 @@ func sortFieldValue(obj map[string]dosa.FieldValue) ([]string, []interface{}, er
 	values := make([]interface{}, len(obj))
 	for pos, c := range columns {
 		values[pos] = obj[c]
-		var err error
-		// specially handling for uuid is needed
-		if u, ok := obj[c].(dosa.UUID); ok {
-			values[pos], err = gocql.ParseUUID(string(u))
-			if err != nil {
-				return nil, nil, errors.Wrapf(err, "invalid uuid %s", u)
-			}
-		}
 	}
 
 	return columns, values, nil
@@ -223,9 +215,6 @@ func convertToDOSATypes(ei *dosa.EntityInfo, row map[string]interface{}) map[str
 		raw := v
 		// special handling
 		switch dosaType {
-		case dosa.TUUID:
-			uuid := raw.(gocql.UUID).String()
-			raw = dosa.UUID(uuid)
 		// for whatever reason, gocql returns int for int32 field
 		// TODO: decide whether to store timestamp as int64 for better resolution; see
 		// https://code.uberinternal.com/T733022

--- a/connectors/cassandra/datastore_query.go
+++ b/connectors/cassandra/datastore_query.go
@@ -36,8 +36,8 @@ func prepareConditions(columnConditions map[string][]*dosa.Condition) ([]*dosa.C
 	values := make([]interface{}, len(cc))
 	for i, c := range cc {
 		values[i] = c.Condition.Value
-		// UUIDs must be converted from satori to gocql via string.
 		var err error
+		// UUIDs must be converted from satori to gocql via string.
 		if u, ok := c.Condition.Value.(uuid.UUID); ok {
 			values[i], err = gocql.ParseUUID(u.String())
 			if err != nil {

--- a/connectors/cassandra/datastore_query.go
+++ b/connectors/cassandra/datastore_query.go
@@ -40,7 +40,7 @@ func prepareConditions(columnConditions map[string][]*dosa.Condition) ([]*dosa.C
 		if u, ok := c.Condition.Value.(uuid.UUID); ok {
 			values[i], err = gocql.ParseUUID(u.String())
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, errors.Wrapf(err, "invalid uuid %s", u)
 			}
 		} else {
 			values[i] = c.Condition.Value

--- a/connectors/cassandra/datastore_query.go
+++ b/connectors/cassandra/datastore_query.go
@@ -35,6 +35,7 @@ func prepareConditions(columnConditions map[string][]*dosa.Condition) ([]*dosa.C
 	cc := dosa.NormalizeConditions(columnConditions)
 	values := make([]interface{}, len(cc))
 	for i, c := range cc {
+		values[i] = c.Condition.Value
 		// UUIDs must be converted from satori to gocql via string.
 		var err error
 		if u, ok := c.Condition.Value.(uuid.UUID); ok {
@@ -42,8 +43,6 @@ func prepareConditions(columnConditions map[string][]*dosa.Condition) ([]*dosa.C
 			if err != nil {
 				return nil, nil, errors.Wrapf(err, "invalid uuid %s", u)
 			}
-		} else {
-			values[i] = c.Condition.Value
 		}
 	}
 	return cc, values, nil

--- a/connectors/cassandra/datastore_query.go
+++ b/connectors/cassandra/datastore_query.go
@@ -25,7 +25,6 @@ import (
 	"encoding/base64"
 	"sort"
 
-	"github.com/gocql/gocql"
 	"github.com/pkg/errors"
 	"github.com/uber-go/dosa"
 )
@@ -35,14 +34,6 @@ func prepareConditions(columnConditions map[string][]*dosa.Condition) ([]*dosa.C
 	values := make([]interface{}, len(cc))
 	for i, c := range cc {
 		values[i] = c.Condition.Value
-		var err error
-		// specially handling for uuid is needed
-		if u, ok := c.Condition.Value.(dosa.UUID); ok {
-			values[i], err = gocql.ParseUUID(string(u))
-			if err != nil {
-				return nil, nil, errors.Wrapf(err, "invalid uuid %s", u)
-			}
-		}
 	}
 	return cc, values, nil
 }

--- a/connectors/cassandra/datastore_query_test.go
+++ b/connectors/cassandra/datastore_query_test.go
@@ -24,7 +24,7 @@ import (
 	"context"
 	"testing"
 
-	gouuid "github.com/satori/go.uuid"
+	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/dosa"
 )
@@ -37,7 +37,7 @@ var (
 
 func TestRangeQuery(t *testing.T) {
 	sut := GetTestConnector(t)
-	partitionKey := dosa.UUID(gouuid.NewV4().String())
+	partitionKey := uuid.NewV4()
 	populateEntityRange(t, partitionKey)
 
 	var (
@@ -102,7 +102,7 @@ func TestRangeQuery(t *testing.T) {
 func TestRangeQueryInvalidToken(t *testing.T) {
 	sut := GetTestConnector(t)
 	_, _, err := sut.Range(context.TODO(), testEntityInfo, map[string][]*dosa.Condition{
-		uuidKeyField: {{Op: dosa.Eq, Value: dosa.UUID(gouuid.NewV4().String())}},
+		uuidKeyField: {{Op: dosa.Eq, Value: uuid.NewV4()}},
 	}, []string{int32Field}, "西瓜", pageSize)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "bad token")
@@ -110,7 +110,7 @@ func TestRangeQueryInvalidToken(t *testing.T) {
 
 func TestRangeQueryFieldsToRead(t *testing.T) {
 	sut := GetTestConnector(t)
-	partitionKey := dosa.UUID(gouuid.NewV4().String())
+	partitionKey := uuid.NewV4()
 	populateEntityRange(t, partitionKey)
 
 	res, token, err := sut.Range(context.TODO(), testEntityInfo, map[string][]*dosa.Condition{
@@ -135,7 +135,7 @@ func TestScan(t *testing.T) {
 	sp := "datastore_scan_test"
 	entityInfo := newTestEntityInfo(sp)
 
-	expectedUUIDSet := make(map[dosa.UUID]struct{})
+	expectedUUIDSet := make(map[uuid.UUID]struct{})
 	expectedIntValueSet := make(map[int]struct{})
 
 	// remove any entities from any previous test
@@ -150,7 +150,7 @@ func TestScan(t *testing.T) {
 	}
 
 	for i := 0; i < 100; i++ {
-		id := dosa.UUID(gouuid.NewV4().String())
+		id := uuid.NewV4()
 		expectedUUIDSet[id] = struct{}{}
 		expectedIntValueSet[i] = struct{}{}
 		err := sut.Upsert(context.TODO(), entityInfo, map[string]dosa.FieldValue{
@@ -164,7 +164,7 @@ func TestScan(t *testing.T) {
 		}
 	}
 
-	actualUUIDSet := make(map[dosa.UUID]struct{})
+	actualUUIDSet := make(map[uuid.UUID]struct{})
 	actualIntValueSet := make(map[int]struct{})
 	var (
 		res   []map[string]dosa.FieldValue
@@ -175,7 +175,7 @@ func TestScan(t *testing.T) {
 		res, token, err = sut.Scan(context.TODO(), entityInfo, []string{uuidKeyField, int32Field}, token, 39)
 		assert.NoError(t, err)
 		for _, row := range res {
-			actualUUIDSet[row[uuidKeyField].(dosa.UUID)] = struct{}{}
+			actualUUIDSet[row[uuidKeyField].(uuid.UUID)] = struct{}{}
 			actualIntValueSet[int(row[int32Field].(int32))] = struct{}{}
 		}
 		if len(token) == 0 {
@@ -187,12 +187,12 @@ func TestScan(t *testing.T) {
 	assert.Equal(t, expectedIntValueSet, actualIntValueSet)
 }
 
-func populateEntityRange(t *testing.T, uuid dosa.UUID) {
+func populateEntityRange(t *testing.T, u0 uuid.UUID) {
 	sut := GetTestConnector(t)
 	for _, strKey := range strKeys {
 		for i := 0; i < pageSize; i++ {
 			err := sut.Upsert(context.TODO(), testEntityInfo, map[string]dosa.FieldValue{
-				uuidKeyField:   uuid,
+				uuidKeyField:   u0,
 				stringKeyField: strKey,
 				int64KeyField:  int64(i),
 				int32Field:     int32(i),

--- a/connectors/memory/memory.go
+++ b/connectors/memory/memory.go
@@ -170,9 +170,9 @@ func timeFromUUID(u uuid.UUID) int64 {
 // of the columns are the same, or it will panic
 func compareType(d1 dosa.FieldValue, d2 dosa.FieldValue) int8 {
 	switch d1 := d1.(type) {
-	case dosa.UUID:
-		u1 := uuid.FromStringOrNil(string(d1))
-		u2 := uuid.FromStringOrNil(string(d2.(dosa.UUID)))
+	case uuid.UUID:
+		u1 := uuid.FromStringOrNil(d1.String())
+		u2 := uuid.FromStringOrNil(d2.(uuid.UUID).String())
 		if u1.Version() != u2.Version() {
 			if u1.Version() < u2.Version() {
 				return -1
@@ -193,10 +193,10 @@ func compareType(d1 dosa.FieldValue, d2 dosa.FieldValue) int8 {
 		}
 
 		// version
-		if string(d1) == string(d2.(dosa.UUID)) {
+		if d1.String() == d2.(uuid.UUID).String() {
 			return 0
 		}
-		if string(d1) < string(d2.(dosa.UUID)) {
+		if d1.String() < d2.(uuid.UUID).String() {
 			return -1
 		}
 		return 1

--- a/connectors/memory/memory_test.go
+++ b/connectors/memory/memory_test.go
@@ -221,7 +221,7 @@ func TestConnector_Read(t *testing.T) {
 	assert.True(t, dosa.ErrorIsNotFound(err))
 
 	// insert into clustered entity
-	id := dosa.NewUUID()
+	id := uuid.NewV4()
 	err = sut.CreateIfNotExists(context.TODO(), clusteredEi, map[string]dosa.FieldValue{
 		"f1": dosa.FieldValue("key"),
 		"c1": dosa.FieldValue(int64(1)),
@@ -249,7 +249,7 @@ func TestConnector_MultiRead(t *testing.T) {
 	sut := NewConnector()
 
 	// insert into clustered entity
-	id := dosa.NewUUID()
+	id := uuid.NewV4()
 	err := sut.CreateIfNotExists(context.TODO(), clusteredEi, map[string]dosa.FieldValue{
 		"f1": dosa.FieldValue("key"),
 		"c1": dosa.FieldValue(int64(1)),
@@ -291,7 +291,7 @@ func TestConnector_MultiUpsert(t *testing.T) {
 	sut := NewConnector()
 
 	// insert into clustered entity
-	id := dosa.NewUUID()
+	id := uuid.NewV4()
 	errs, err := sut.MultiUpsert(context.TODO(), clusteredEi, []map[string]dosa.FieldValue{{
 		"f1": dosa.FieldValue("key"),
 		"c1": dosa.FieldValue(int64(1)),
@@ -317,7 +317,7 @@ func TestConnector_MultiRemove(t *testing.T) {
 	sut := NewConnector()
 
 	// insert into clustered entity
-	id := dosa.NewUUID()
+	id := uuid.NewV4()
 	err := sut.Upsert(context.TODO(), clusteredEi, map[string]dosa.FieldValue{
 		"f1": dosa.FieldValue("key"),
 		"c1": dosa.FieldValue(int64(1)),
@@ -375,7 +375,7 @@ func TestConnector_Remove(t *testing.T) {
 	assert.NoError(t, err)
 
 	// insert into clustered entity
-	id := dosa.NewUUID()
+	id := uuid.NewV4()
 	err = sut.CreateIfNotExists(context.TODO(), clusteredEi, map[string]dosa.FieldValue{
 		"f1": dosa.FieldValue("key"),
 		"c1": dosa.FieldValue(int64(1)),
@@ -387,7 +387,7 @@ func TestConnector_Remove(t *testing.T) {
 	err = sut.Remove(context.TODO(), clusteredEi, map[string]dosa.FieldValue{
 		"f1": dosa.FieldValue("key"),
 		"c1": dosa.FieldValue(int64(1)),
-		"c7": dosa.FieldValue(dosa.NewUUID())})
+		"c7": dosa.FieldValue(uuid.NewV4())})
 	assert.NoError(t, err)
 
 	// and remove the partitioned value
@@ -405,7 +405,7 @@ func TestConnector_Remove(t *testing.T) {
 	assert.NoError(t, err)
 
 	// insert into entity primary key'd on [f1, c1] and indexed on [f1, c2, c1]
-	id = dosa.NewUUID()
+	id = uuid.NewV4()
 	err = sut.CreateIfNotExists(context.TODO(), clusteredByTimeEi, map[string]dosa.FieldValue{
 		"f1": dosa.FieldValue("key"),
 		"c1": dosa.FieldValue(int64(1)),
@@ -434,7 +434,7 @@ func TestConnector_RemoveRange(t *testing.T) {
 		err := sut.CreateIfNotExists(context.TODO(), clusteredEi, map[string]dosa.FieldValue{
 			"f1": dosa.FieldValue("data"),
 			"c1": dosa.FieldValue(int64(x)),
-			"c7": dosa.FieldValue(dosa.NewUUID())})
+			"c7": dosa.FieldValue(uuid.NewV4())})
 		assert.NoError(t, err)
 	}
 
@@ -511,9 +511,9 @@ func TestConnector_Shutdown(t *testing.T) {
 func TestConnector_CreateIfNotExists2(t *testing.T) {
 	sut := NewConnector()
 
-	testUUIDs := make([]dosa.UUID, 10)
+	testUUIDs := make([]uuid.UUID, 10)
 	for x := 0; x < 10; x++ {
-		testUUIDs[x] = dosa.NewUUID()
+		testUUIDs[x] = uuid.NewV4()
 	}
 
 	// first, insert 10 random UUID values into same partition key
@@ -530,7 +530,7 @@ func TestConnector_CreateIfNotExists2(t *testing.T) {
 			"f1": dosa.FieldValue("data"),
 			"c1": dosa.FieldValue(int64(1)),
 			"c7": dosa.FieldValue(testUUIDs[x])})
-		assert.Error(t, err, string(testUUIDs[x]))
+		assert.Error(t, err, testUUIDs[x].String())
 		assert.True(t, dosa.ErrorIsAlreadyExists(err))
 	}
 	// now, insert them again, but this time with a different secondary key
@@ -560,9 +560,9 @@ func TestConnector_CreateIfNotExists2(t *testing.T) {
 func TestConnector_Upsert2(t *testing.T) {
 	sut := NewConnector()
 
-	testUUIDs := make([]dosa.UUID, 10)
+	testUUIDs := make([]uuid.UUID, 10)
 	for x := 0; x < 10; x++ {
-		testUUIDs[x] = dosa.NewUUID()
+		testUUIDs[x] = uuid.NewV4()
 	}
 
 	// first, insert 10 random UUID values into same partition key
@@ -621,9 +621,9 @@ func TestConnector_Range(t *testing.T) {
 
 	// insert some data into data/1/uuid with a random set of uuids
 	// we insert them in a random order
-	testUUIDs := make([]dosa.UUID, idcount)
+	testUUIDs := make([]uuid.UUID, idcount)
 	for x := 0; x < idcount; x++ {
-		testUUIDs[x] = dosa.NewUUID()
+		testUUIDs[x] = uuid.NewV4()
 	}
 	for x := 0; x < idcount; x++ {
 		err := sut.CreateIfNotExists(context.TODO(), clusteredEi, map[string]dosa.FieldValue{
@@ -739,9 +739,9 @@ func TestConnector_TUUIDs(t *testing.T) {
 
 	// insert some data into data/1/uuid with a random set of uuids
 	// we insert them in a random order
-	testUUIDs := make([]dosa.UUID, idcount)
+	testUUIDs := make([]uuid.UUID, idcount)
 	for x := 0; x < idcount; x++ {
-		testUUIDs[x] = dosa.NewUUID()
+		testUUIDs[x] = uuid.NewV4()
 	}
 
 	// insert a bunch of values with V1 timestamps as clustering keys
@@ -767,7 +767,7 @@ func TestConnector_TUUIDs(t *testing.T) {
 	}
 
 	for x := 0; x < idcount; x++ {
-		testUUIDs = append(testUUIDs, dosa.NewUUID())
+		testUUIDs = append(testUUIDs, uuid.NewV4())
 	}
 
 	// now mix in a few V4 UUIDs
@@ -793,16 +793,16 @@ func TestConnector_TUUIDs(t *testing.T) {
 	}
 }
 
-type ByUUID []dosa.UUID
+type ByUUID []uuid.UUID
 
 func (u ByUUID) Len() int           { return len(u) }
 func (u ByUUID) Swap(i, j int)      { u[i], u[j] = u[j], u[i] }
-func (u ByUUID) Less(i, j int) bool { return string(u[i]) < string(u[j]) }
+func (u ByUUID) Less(i, j int) bool { return u[i].String() < u[j].String() }
 
 func BenchmarkConnector_CreateIfNotExists(b *testing.B) {
 	sut := NewConnector()
 	for x := 0; x < b.N; x++ {
-		id := dosa.NewUUID()
+		id := uuid.NewV4()
 		err := sut.CreateIfNotExists(context.TODO(), clusteredEi, map[string]dosa.FieldValue{
 			"f1": dosa.FieldValue("key"),
 			"c1": dosa.FieldValue(int64(1)),
@@ -816,9 +816,9 @@ func BenchmarkConnector_CreateIfNotExists(b *testing.B) {
 
 func BenchmarkConnector_Read(b *testing.B) {
 	const idcount = 100
-	testUUIDs := make([]dosa.UUID, idcount)
+	testUUIDs := make([]uuid.UUID, idcount)
 	for x := 0; x < idcount; x++ {
-		testUUIDs[x] = dosa.NewUUID()
+		testUUIDs[x] = uuid.NewV4()
 	}
 	sut := NewConnector()
 	for x := 0; x < idcount; x++ {
@@ -839,9 +839,9 @@ func BenchmarkConnector_Read(b *testing.B) {
 }
 
 func TestCompareType(t *testing.T) {
-	tuuid := dosa.NewUUID()
-	v1uuid := dosa.UUID(uuid.NewV1().String())
-	v1newer := dosa.UUID(uuid.NewV1().String())
+	tuuid := uuid.NewV4()
+	v1uuid := uuid.NewV1()
+	v1newer := uuid.NewV1()
 	tests := []struct {
 		t1, t2 dosa.FieldValue
 		result int8
@@ -887,9 +887,9 @@ func TestConnector_Scan(t *testing.T) {
 	sut := NewConnector()
 	const idcount = 10
 
-	testUUIDs := make([]dosa.UUID, idcount)
+	testUUIDs := make([]uuid.UUID, idcount)
 	for x := 0; x < idcount; x++ {
-		testUUIDs[x] = dosa.NewUUID()
+		testUUIDs[x] = uuid.NewV4()
 	}
 	// scan with nothing there yet
 	_, token, err := sut.Scan(context.TODO(), clusteredEi, dosa.All(), "", 100)
@@ -1196,23 +1196,23 @@ func TestCompoundPartSecondaryIndex(t *testing.T) {
 	bucketID := 1
 	now := time.Now()
 
-	repoUUID0 := uuid.NewV4().String()
+	repoUUID0 := uuid.NewV4()
 	createdAt0 := now.Add(-1 * time.Hour)
 	result0 := 5
 
 	err := sut.Upsert(context.TODO(), compoundPartEi, map[string]dosa.FieldValue{
-		"RepositoryUUID": dosa.FieldValue(dosa.UUID(repoUUID0)),
+		"RepositoryUUID": dosa.FieldValue(repoUUID0),
 		"BucketID":       dosa.FieldValue(int32(bucketID)),
 		"CreatedAt":      dosa.FieldValue(createdAt0),
 		"Result":         dosa.FieldValue(int32(result0)),
 	})
 
-	repoUUID1 := uuid.NewV4().String()
+	repoUUID1 := uuid.NewV4()
 	createdAt1 := now.Add(-2 * time.Hour)
 	result1 := 4
 
 	err = sut.Upsert(context.TODO(), compoundPartEi, map[string]dosa.FieldValue{
-		"RepositoryUUID": dosa.FieldValue(dosa.UUID(repoUUID1)),
+		"RepositoryUUID": dosa.FieldValue(repoUUID1),
 		"BucketID":       dosa.FieldValue(int32(bucketID)),
 		"CreatedAt":      dosa.FieldValue(createdAt1),
 		"Result":         dosa.FieldValue(int32(result1)),
@@ -1221,7 +1221,7 @@ func TestCompoundPartSecondaryIndex(t *testing.T) {
 	assert.NoError(t, err)
 
 	pk0 := map[string]dosa.FieldValue{
-		"RepositoryUUID": dosa.FieldValue(dosa.UUID(repoUUID0)),
+		"RepositoryUUID": dosa.FieldValue(repoUUID0),
 		"BucketID":       dosa.FieldValue(int32(bucketID)),
 	}
 	readVals0, err := sut.Read(context.TODO(), compoundPartEi, pk0, dosa.All())
@@ -1230,7 +1230,7 @@ func TestCompoundPartSecondaryIndex(t *testing.T) {
 	assert.Equal(t, readVals0["CreatedAt"], createdAt0)
 
 	pk1 := map[string]dosa.FieldValue{
-		"RepositoryUUID": dosa.FieldValue(dosa.UUID(repoUUID1)),
+		"RepositoryUUID": dosa.FieldValue(repoUUID1),
 		"BucketID":       dosa.FieldValue(int32(bucketID)),
 	}
 	readVals1, err := sut.Read(context.TODO(), compoundPartEi, pk1, dosa.All())
@@ -1284,7 +1284,7 @@ func TestReadRaceClustered(t *testing.T) {
 	// we leak internal state and cause a data race when reading and writing
 	// similar values.
 
-	testUUID := dosa.NewUUID()
+	testUUID := uuid.NewV4()
 
 	err := sut.Upsert(context.TODO(), clusteredEi, map[string]dosa.FieldValue{
 		"f1": dosa.FieldValue("part1"),
@@ -1371,9 +1371,9 @@ func TestRangeRace(t *testing.T) {
 	// data race when reading and writing similar values.
 
 	sut := NewConnector()
-	uuid0 := dosa.NewUUID()
-	uuid1 := dosa.NewUUID()
-	uuid2 := dosa.NewUUID()
+	uuid0 := uuid.NewV4()
+	uuid1 := uuid.NewV4()
+	uuid2 := uuid.NewV4()
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 
@@ -1561,7 +1561,7 @@ func createTestData(t *testing.T, sut *Connector, keyGenFunc func(int) string, i
 			"f1": dosa.FieldValue(keyGenFunc(x)),
 			"c1": dosa.FieldValue(int64(1)),
 			"c6": dosa.FieldValue(int32(x)),
-			"c7": dosa.FieldValue(dosa.UUID(uuid.NewV1().String()))})
+			"c7": dosa.FieldValue(uuid.NewV1())})
 		assert.NoError(t, err)
 	}
 }

--- a/connectors/random/random_test.go
+++ b/connectors/random/random_test.go
@@ -26,6 +26,7 @@ import (
 
 	"time"
 
+	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/dosa"
 	"github.com/uber-go/dosa/connectors/random"
@@ -42,7 +43,7 @@ type AllTypes struct {
 	StringType  string
 	BlobType    []byte
 	TimeType    time.Time
-	UUIDType    dosa.UUID
+	UUIDType    uuid.UUID
 }
 
 var (

--- a/connectors/routing/connector_test.go
+++ b/connectors/routing/connector_test.go
@@ -255,9 +255,9 @@ func TestConnector_CreateIfNotExists2(t *testing.T) {
 	connectorMap := getConnectorMap()
 	rc := NewConnector(cfg, connectorMap, nil)
 
-	testUUIDs := make([]dosa.UUID, 10)
+	testUUIDs := make([]uuid.UUID, 10)
 	for x := 0; x < 10; x++ {
-		testUUIDs[x] = dosa.NewUUID()
+		testUUIDs[x] = uuid.NewV4()
 	}
 
 	// first, insert 10 random UUID values into same partition key
@@ -274,7 +274,7 @@ func TestConnector_CreateIfNotExists2(t *testing.T) {
 			"f1": dosa.FieldValue("data"),
 			"c1": dosa.FieldValue(int64(1)),
 			"c7": dosa.FieldValue(testUUIDs[x])})
-		assert.Error(t, err, string(testUUIDs[x]))
+		assert.Error(t, err, testUUIDs[x].String())
 		assert.True(t, dosa.ErrorIsAlreadyExists(err))
 	}
 	// now, insert them again, but this time with a different secondary key
@@ -356,7 +356,7 @@ func TestConnector_Read(t *testing.T) {
 	assert.True(t, dosa.ErrorIsNotFound(err))
 
 	// insert into clustered entity
-	id := dosa.NewUUID()
+	id := uuid.NewV4()
 
 	err = rc.CreateIfNotExists(ctx, clusteredEi, map[string]dosa.FieldValue{
 		"f1": dosa.FieldValue("key"),
@@ -431,9 +431,9 @@ func TestConnector_Upsert(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), `partition key "p1"`)
 
-	testUUIDs := make([]dosa.UUID, 10)
+	testUUIDs := make([]uuid.UUID, 10)
 	for x := 0; x < 10; x++ {
-		testUUIDs[x] = dosa.NewUUID()
+		testUUIDs[x] = uuid.NewV4()
 	}
 
 	// first, insert 10 random UUID values into same partition key
@@ -538,7 +538,7 @@ func TestConnector_Remove(t *testing.T) {
 	assert.NoError(t, err)
 
 	// insert into clustered entity
-	id := dosa.NewUUID()
+	id := uuid.NewV4()
 	err = rc.CreateIfNotExists(ctx, clusteredEi, map[string]dosa.FieldValue{
 		"f1": dosa.FieldValue("key"),
 		"c1": dosa.FieldValue(int64(1)),
@@ -550,7 +550,7 @@ func TestConnector_Remove(t *testing.T) {
 	err = rc.Remove(ctx, clusteredEi, map[string]dosa.FieldValue{
 		"f1": dosa.FieldValue("key"),
 		"c1": dosa.FieldValue(int64(1)),
-		"c7": dosa.FieldValue(dosa.NewUUID())})
+		"c7": dosa.FieldValue(uuid.NewV4())})
 	assert.NoError(t, err)
 
 	// and remove the partitioned value
@@ -592,7 +592,7 @@ func TestConnector_RemoveRange(t *testing.T) {
 		err := rc.CreateIfNotExists(ctx, clusteredEi, map[string]dosa.FieldValue{
 			"f1": dosa.FieldValue("data"),
 			"c1": dosa.FieldValue(int64(x)),
-			"c7": dosa.FieldValue(dosa.NewUUID())})
+			"c7": dosa.FieldValue(uuid.NewV4())})
 		assert.NoError(t, err)
 	}
 
@@ -695,11 +695,11 @@ func TestConnector_MultiRemove(t *testing.T) {
 	assert.Contains(t, err.Error(), "dummy errors")
 }
 
-type ByUUID []dosa.UUID
+type ByUUID []uuid.UUID
 
 func (u ByUUID) Len() int           { return len(u) }
 func (u ByUUID) Swap(i, j int)      { u[i], u[j] = u[j], u[i] }
-func (u ByUUID) Less(i, j int) bool { return string(u[i]) < string(u[j]) }
+func (u ByUUID) Less(i, j int) bool { return u[i].String() < u[j].String() }
 
 func TestConnector_Range(t *testing.T) {
 	connectorMap := getConnectorMap()
@@ -715,9 +715,9 @@ func TestConnector_Range(t *testing.T) {
 
 	// insert some data into data/1/uuid with a random set of uuids
 	// we insert them in a random order
-	testUUIDs := make([]dosa.UUID, idcount)
+	testUUIDs := make([]uuid.UUID, idcount)
 	for x := 0; x < idcount; x++ {
-		testUUIDs[x] = dosa.NewUUID()
+		testUUIDs[x] = uuid.NewV4()
 	}
 	for x := 0; x < idcount; x++ {
 		err := rc.CreateIfNotExists(ctx, clusteredEi, map[string]dosa.FieldValue{
@@ -834,9 +834,9 @@ func TestConnector_Scan(t *testing.T) {
 	connectorMap := getConnectorMap()
 	rc := NewConnector(cfg, connectorMap, nil)
 
-	testUUIDs := make([]dosa.UUID, idcount)
+	testUUIDs := make([]uuid.UUID, idcount)
 	for x := 0; x < idcount; x++ {
-		testUUIDs[x] = dosa.NewUUID()
+		testUUIDs[x] = uuid.NewV4()
 	}
 	// scan with nothing there yet
 	_, token, err := rc.Scan(ctx, clusteredEi, dosa.All(), "", 100)
@@ -891,9 +891,9 @@ func TestConnector_TUUIDs(t *testing.T) {
 	connectorMap := getConnectorMap()
 	rc := NewConnector(cfg, connectorMap, nil)
 
-	testUUIDs := make([]dosa.UUID, idcount)
+	testUUIDs := make([]uuid.UUID, idcount)
 	for x := 0; x < idcount; x++ {
-		testUUIDs[x] = dosa.NewUUID()
+		testUUIDs[x] = uuid.NewV4()
 	}
 
 	// insert a bunch of values with V1 timestamps as clustering keys
@@ -919,7 +919,7 @@ func TestConnector_TUUIDs(t *testing.T) {
 	}
 
 	for x := 0; x < idcount; x++ {
-		testUUIDs = append(testUUIDs, dosa.NewUUID())
+		testUUIDs = append(testUUIDs, uuid.NewV4())
 	}
 
 	// now mix in a few V4 UUIDs
@@ -1135,7 +1135,7 @@ func createTestData(t *testing.T, rc *Connector, keyGenFunc func(int) string, id
 			"f1": dosa.FieldValue(keyGenFunc(x)),
 			"c1": dosa.FieldValue(int64(1)),
 			"c6": dosa.FieldValue(int32(x)),
-			"c7": dosa.FieldValue(dosa.UUID(uuid.NewV1().String()))})
+			"c7": dosa.FieldValue(uuid.NewV1())})
 		assert.NoError(t, err)
 	}
 }

--- a/connectors/yarpc/helpers_test.go
+++ b/connectors/yarpc/helpers_test.go
@@ -70,28 +70,6 @@ func TestRawValueFromInterfaceNilBlob(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestRawValueConversionError(t *testing.T) {
-	data := []struct {
-		input  interface{}
-		errmsg string
-	}{
-		{dosa.UUID(""), ErrInCorrectUUIDLength}, // empty string
-		{dosa.UUID("1"), ErrInCorrectUUIDLength},
-		{dosa.UUID("this is not a uuid, uuids shouldnt contain something like a t in them"), "incorrect UUID"},
-	}
-
-	for _, test := range data {
-		_, err := RawValueFromInterface(test.input)
-		assert.Error(t, err, "test %+v", test)
-		assert.Contains(t, err.Error(), test.errmsg, "test %+v", test)
-	}
-
-	// happy path
-	v, err := RawValueFromInterface(dosa.UUID("80bccd66-9517-4f54-9dec-0ddb87d0dc2a"))
-	assert.NoError(t, err)
-	assert.NotNil(t, v)
-}
-
 // TODO: add additional happy path unit tests here. The helpers currently get
 // good coverage from the connectors though.
 

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -26,7 +26,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/uber-go/dosa"
+	"github.com/satori/go.uuid"
 )
 
 // Encoder serializes and deserializes the data in cache
@@ -56,7 +56,7 @@ func (j *jsonEncoder) Decode(data []byte, v interface{}) error {
 func NewGobEncoder() GobEncoder {
 	// Register non-primitive dosa types
 	gob.Register(time.Time{})
-	gob.Register(dosa.NewUUID())
+	gob.Register(uuid.UUID{})
 	return GobEncoder{}
 }
 

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/dosa"
 	"github.com/uber-go/dosa/encoding"
@@ -57,10 +58,10 @@ func TestGobEncoder_Encode(t *testing.T) {
 }
 
 func TestGobEncoder_Register(t *testing.T) {
-	u := dosa.UUID("uuid-pointer")
+	u := uuid.NewV4()
 	ts := time.Now()
 	bytes, err := g.Encode(map[string]dosa.FieldValue{
-		"uuidField":    dosa.UUID("some-uuid"),
+		"uuidField":    uuid.NewV4(),
 		"timeField":    ts,
 		"uuidFieldPtr": &u,
 		"timeFieldPtr": &ts,

--- a/entity_parser.go
+++ b/entity_parser.go
@@ -29,6 +29,7 @@ import (
 	"unicode"
 
 	"github.com/pkg/errors"
+	"github.com/satori/go.uuid"
 )
 
 const (
@@ -490,7 +491,7 @@ func parensBalanced(s string) bool {
 }
 
 var (
-	uuidType       = reflect.TypeOf(UUID(""))
+	uuidType       = reflect.TypeOf(uuid.UUID{})
 	blobType       = reflect.TypeOf([]byte{})
 	timestampType  = reflect.TypeOf(time.Time{})
 	int32Type      = reflect.TypeOf(int32(0))
@@ -503,7 +504,7 @@ var (
 	nullInt64Type  = reflect.TypeOf((*int64)(nil))
 	nullDoubleType = reflect.TypeOf((*float64)(nil))
 	nullStringType = reflect.TypeOf((*string)(nil))
-	nullUUIDType   = reflect.TypeOf((*UUID)(nil))
+	nullUUIDType   = reflect.TypeOf((*uuid.UUID)(nil))
 	nullTimeType   = reflect.TypeOf((*time.Time)(nil))
 )
 

--- a/entity_parser_test.go
+++ b/entity_parser_test.go
@@ -27,6 +27,7 @@ import (
 
 	"io"
 
+	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -292,14 +293,14 @@ type AllTypes struct {
 	StringType     string
 	BlobType       []byte
 	TimeType       time.Time
-	UUIDType       UUID
+	UUIDType       uuid.UUID
 	NullBoolType   *bool
 	NullInt32Type  *int32
 	NullInt64Type  *int64
 	NullDoubleType *float64
 	NullStringType *string
 	NullTimeType   *time.Time
-	NullUUIDType   *UUID
+	NullUUIDType   *uuid.UUID
 }
 
 func TestAllTypes(t *testing.T) {
@@ -357,7 +358,7 @@ type NullableType struct {
 	NullDoubleType *float64
 	NullStringType *string
 	NullTimeType   *time.Time
-	NullUUIDType   *UUID
+	NullUUIDType   *uuid.UUID
 }
 
 func TestNullableType(t *testing.T) {
@@ -458,7 +459,7 @@ type NullStringPrimaryKeyType struct {
 
 type NullUUIDPrimaryKeyType struct {
 	Entity       `dosa:"primaryKey=NullUUIDType"`
-	NullUUIDType *UUID
+	NullUUIDType *uuid.UUID
 }
 
 type NullTimePrimaryKeyType struct {

--- a/examples/testing/testing.go
+++ b/examples/testing/testing.go
@@ -24,13 +24,14 @@ import (
 	"context"
 	"time"
 
+	"github.com/satori/go.uuid"
 	"github.com/uber-go/dosa"
 )
 
 // User is a user record
 type User struct {
 	dosa.Entity `dosa:"primaryKey=UUID"`
-	UUID        dosa.UUID
+	UUID        uuid.UUID
 	Name        string
 	Email       string
 	CreatedOn   time.Time
@@ -39,8 +40,8 @@ type User struct {
 // MenuItem represents a single item on a Menu.
 type MenuItem struct {
 	dosa.Entity  `dosa:"primaryKey=((MenuUUID), MenuItemUUID)"`
-	MenuUUID     dosa.UUID
-	MenuItemUUID dosa.UUID
+	MenuUUID     uuid.UUID
+	MenuItemUUID uuid.UUID
 	Name         string
 	Description  string
 }
@@ -61,7 +62,7 @@ func NewDatastore(c dosa.Client) (*Datastore, error) {
 }
 
 // GetUser fetches a user from the datastore by uuid
-func (d *Datastore) GetUser(ctx context.Context, uuid dosa.UUID) (*User, error) {
+func (d *Datastore) GetUser(ctx context.Context, uuid uuid.UUID) (*User, error) {
 	user := &User{UUID: uuid}
 	readCtx, readCancelFn := context.WithTimeout(ctx, 1*time.Second)
 	defer readCancelFn()
@@ -74,7 +75,7 @@ func (d *Datastore) GetUser(ctx context.Context, uuid dosa.UUID) (*User, error) 
 }
 
 // GetMenu fetches all of the MenuItems for the menu specified by menuUUID.
-func (d *Datastore) GetMenu(ctx context.Context, menuUUID dosa.UUID) ([]*MenuItem, error) {
+func (d *Datastore) GetMenu(ctx context.Context, menuUUID uuid.UUID) ([]*MenuItem, error) {
 	op := dosa.NewRangeOp(&MenuItem{}).Eq("MenuUUID", menuUUID).Limit(50)
 	rangeCtx, rangeCancelFn := context.WithTimeout(ctx, 1*time.Second)
 	defer rangeCancelFn()

--- a/examples/testing/testing_test.go
+++ b/examples/testing/testing_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/satori/go.uuid"
 	"github.com/uber-go/dosa"
 	examples "github.com/uber-go/dosa/examples/testing"
 	"github.com/uber-go/dosa/mocks"
@@ -35,18 +36,18 @@ import (
 
 var (
 	ctx       = context.TODO()
-	uuid      = dosa.NewUUID()
-	user      = &examples.User{UUID: uuid}
-	menuUUID  = dosa.NewUUID()
+	uid0      = uuid.NewV4()
+	user      = &examples.User{UUID: uid0}
+	menuUUID  = uuid.NewV4()
 	menuItem1 = &examples.MenuItem{
 		MenuUUID:     menuUUID,
-		MenuItemUUID: dosa.NewUUID(),
+		MenuItemUUID: uuid.NewV4(),
 		Name:         "Burrito",
 		Description:  "A large wheat flour tortilla with a filling",
 	}
 	menuItem2 = &examples.MenuItem{
 		MenuUUID:     menuUUID,
-		MenuItemUUID: dosa.NewUUID(),
+		MenuItemUUID: uuid.NewV4(),
 		Name:         "Waffel",
 		Description:  "Cooked batter in a circular grid pattern",
 	}
@@ -83,7 +84,7 @@ func TestGetUser(t *testing.T) {
 	c1.EXPECT().Read(gomock.Any(), nil, user).Return(errors.New("Read Error")).Times(1)
 	ds1, _ := examples.NewDatastore(c1)
 
-	u1, err1 := ds1.GetUser(ctx, uuid)
+	u1, err1 := ds1.GetUser(ctx, uid0)
 	assert.Error(t, err1)
 	assert.Nil(t, u1)
 
@@ -93,7 +94,7 @@ func TestGetUser(t *testing.T) {
 	c2.EXPECT().Read(gomock.Any(), nil, user).Return(nil).Times(1)
 	ds2, _ := examples.NewDatastore(c2)
 
-	u2, err2 := ds2.GetUser(ctx, uuid)
+	u2, err2 := ds2.GetUser(ctx, uid0)
 	assert.NoError(t, err2)
 	assert.Equal(t, u2, user)
 }

--- a/finder_test.go
+++ b/finder_test.go
@@ -147,12 +147,12 @@ func TestStringToDosaType(t *testing.T) {
 		{"*UUID", "", TUUID, true},
 
 		// Tests with package name that doesn't end with dot.
-		{"dosa.UUID", "dosa", TUUID, false},
-		{"*dosa.UUID", "dosa", TUUID, true},
+		{"uuid.UUID", "uuid", TUUID, false},
+		{"*uuid.UUID", "uuid", TUUID, true},
 
 		// Tests with package name that ends with dot.
-		{"dosav2.UUID", "dosav2.", TUUID, false},
-		{"*dosav2.UUID", "dosav2.", TUUID, true},
+		{"satori.UUID", "satori.", TUUID, false},
+		{"*satori.UUID", "satori.", TUUID, true},
 
 		{"unknown", "", Invalid, false},
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 8b504c7412567ab097019fc80fff8dc43647b3247180549699dcadd3d57244e8
-updated: 2018-04-06T14:54:41.617824-07:00
+hash: 26723c31f7ddad39b26abf2a748856acc972abf1f9f9f756c35067074eefc675
+updated: 2018-04-23T18:24:50.276191-07:00
 imports:
 - name: github.com/beorn7/perks
-  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  version: 3a771d992973f24aa725d07868b467d1ddfceafb
   subpackages:
   - quantile
 - name: github.com/elodina/go-avro
@@ -15,7 +15,7 @@ imports:
   - internal
   - redis
 - name: github.com/gobwas/glob
-  version: 51eb1ee00b6d931c66d229ceeb7c31b985563420
+  version: f00a7392b43971b2fdb562418faab1f18da2067a
   subpackages:
   - compiler
   - match
@@ -35,7 +35,7 @@ imports:
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
-  version: 925541529c1fa6821df4e44ce2723319eb2be768
+  version: e09c5db296004fbe3f74490e84dcd62c3c5ddb1b
   subpackages:
   - proto
 - name: github.com/golang/snappy
@@ -65,13 +65,13 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 2f17f4a9d485bf34b4bfaccc273805040e4f86c8
+  version: e5b036cc37a466a0af27d604d1ee500211d16d6a
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: cb4147076ac75738c9a7d279075a253c0cc5acbd
+  version: 8b1c2da0d56deffdbb9e48d4414b4e674bd8083e
   subpackages:
   - internal/util
   - nfs
@@ -162,7 +162,7 @@ imports:
   - yarpcconfig
   - yarpcerrors
 - name: go.uber.org/zap
-  version: 35aad584952c3e7020db7b839f6b102de6271f89
+  version: eeedf312bc6c57391d84767a4cd413f02a917974
   subpackages:
   - buffer
   - internal/bufferpool
@@ -170,7 +170,7 @@ imports:
   - internal/exit
   - zapcore
 - name: golang.org/x/net
-  version: b3c676e531a6dc479fa1b35ac961c13f5e2b4d2e
+  version: 5f9ae10d9af5b1c89ae6904293b14b064d4ada23
   subpackages:
   - bpf
   - context
@@ -179,9 +179,9 @@ imports:
   - ipv4
   - ipv6
 - name: gopkg.in/inf.v0
-  version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
+  version: d2d2541c53f18d2a059457998ce2876cc8e67cbf
 - name: gopkg.in/yaml.v2
-  version: d670f9405373e636a5a2765eea47fac0c9bc91a4
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 testImports:
 - name: github.com/anmitsu/go-shlex
   version: 648efa622239a2f6ff949fed78ee37b48d499ba4
@@ -190,23 +190,23 @@ testImports:
   subpackages:
   - gocov
 - name: github.com/davecgh/go-spew
-  version: 346938d642f2ec3594ed81d874461961cd0faa76
+  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
   subpackages:
   - spew
 - name: github.com/go-playground/overalls
-  version: b472d5a5b9424bffa8444021b47d1b7b4c894b23
+  version: 22ec1a223b7c9a2e56355bd500b539cba3784238
 - name: github.com/golang/lint
-  version: e14d9b0f1d332b1420c1ffa32562ad2dc84d645d
+  version: 85993ffd0a6cd043291f3f63d45d656d97b165bd
   subpackages:
   - golint
 - name: github.com/kisielk/errcheck
-  version: b1445a9dd8285a50c6d1661d16f0a9ceb08125f7
+  version: 8050dd7cc11578becd8622667107bb21a7baf451
 - name: github.com/kisielk/gotool
-  version: d6ce6262d87e3a4e153e86023ff56ae771554a41
+  version: 80517062f582ea3340cd4baf70e86d539ae7d84d
 - name: github.com/matm/gocov-html
   version: f6dd0fd0ebc7c8cff8b24c0a585caeef250627a3
 - name: github.com/mattn/goveralls
-  version: b71a1e4855f87991aff01c2c833a75a07059c61c
+  version: 1c14a4061c1cb86f0310cc0d4c0b5bc743879bc5
 - name: github.com/pmezard/go-difflib
   version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
@@ -224,6 +224,6 @@ testImports:
 - name: github.com/yookoala/realpath
   version: d19ef9c409d9817c1e685775e53d361b03eabbc8
 - name: golang.org/x/tools
-  version: 25101aadb97aa42907eee6a238d6d26a6cb3c756
+  version: 94b14834a20132093826ea5e2da5502a13908ad3
   subpackages:
   - cover

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,7 +10,7 @@ import:
 - package: github.com/pkg/errors
   version: ^0.8.0
 - package: github.com/satori/go.uuid
-  version: ^1.1.0
+  version: 1.2.0
 - package: github.com/uber/dosa-idl
   version: ttl-for-multi-upsert
   subpackages:

--- a/range_conditions.go
+++ b/range_conditions.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/satori/go.uuid"
 )
 
 // Condition holds an operator and a value for a condition on a field.
@@ -228,8 +229,8 @@ func ensureValidConditions(t Type, conditions []*Condition) error {
 func compare(t Type, a, b interface{}) int {
 	switch t {
 	case TUUID:
-		// TODO: make sure if comparison for UUID like below makes sense.
-		return strings.Compare(string(a.(UUID)), string(b.(UUID)))
+		// Comparing UUIDs (except for equality) really makes no sense, but ....
+		return strings.Compare(a.(uuid.UUID).String(), b.(uuid.UUID).String())
 	case Int64:
 		return int(a.(int64) - b.(int64))
 	case Int32:
@@ -275,7 +276,7 @@ func compare(t Type, a, b interface{}) int {
 func ensureTypeMatch(t Type, v FieldValue) error {
 	switch t {
 	case TUUID:
-		if _, ok := v.(UUID); !ok {
+		if _, ok := v.(uuid.UUID); !ok {
 			return errors.Errorf("invalid value for UUID type: %v", v)
 		}
 	case Int64:

--- a/range_conditions_wb_test.go
+++ b/range_conditions_wb_test.go
@@ -26,8 +26,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 )
+
+func UUID(s string) uuid.UUID {
+	return uuid.Must(uuid.FromString(s))
+}
 
 // White box tests for unexported, stateless helper methods
 

--- a/scan_test.go
+++ b/scan_test.go
@@ -27,6 +27,7 @@ import (
 
 	"time"
 
+	"github.com/satori/go.uuid"
 	"github.com/uber-go/dosa"
 )
 
@@ -39,14 +40,14 @@ type AllTypesScanTestEntity struct {
 	StringType     string
 	BlobType       []byte
 	TimeType       time.Time
-	UUIDType       dosa.UUID
+	UUIDType       uuid.UUID
 	NullBoolType   *bool
 	NullInt32Type  *int32
 	NullInt64Type  *int64
 	NullDoubleType *float64
 	NullStringType *string
 	NullTimeType   *time.Time
-	NullUUIDType   *dosa.UUID
+	NullUUIDType   *uuid.UUID
 }
 
 func TestNewScanOp(t *testing.T) {

--- a/schema/cql/cql_test.go
+++ b/schema/cql/cql_test.go
@@ -26,6 +26,7 @@ import (
 
 	"time"
 
+	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/dosa"
 )
@@ -41,7 +42,7 @@ type AllTypes struct {
 	StringType  string
 	BlobType    []byte
 	TimeType    time.Time
-	UUIDType    dosa.UUID
+	UUIDType    uuid.UUID
 }
 
 type SinglePrimaryKey struct {

--- a/testclient/testclient_test.go
+++ b/testclient/testclient_test.go
@@ -24,8 +24,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
-	"github.com/uber-go/dosa"
 	"github.com/uber-go/dosa/testentity"
 )
 
@@ -36,7 +36,7 @@ func TestTestClient(t *testing.T) {
 	err = client.Initialize(context.Background())
 	assert.NoError(t, err)
 
-	uuid := dosa.NewUUID()
+	uuid := uuid.NewV4()
 	testEnt := testentity.TestEntity{
 		UUIDKey:  uuid,
 		StrKey:   "key",

--- a/testentity/named_import_testentity.go
+++ b/testentity/named_import_testentity.go
@@ -25,16 +25,17 @@ import (
 
 	// Using a named import is the key change in this file. This is
 	// used to test the entity parser against named dosa imports.
+	"github.com/satori/go.uuid"
 	dosav2 "github.com/uber-go/dosa"
 )
 
 // TestNamedImportEntity uses common key types and all types in value fields.
 type TestNamedImportEntity struct {
 	dosav2.Entity `dosa:"name=named_import_entity, primaryKey=(UUIDKey, StrKey ASC, Int64Key DESC)"`
-	UUIDKey       dosav2.UUID `dosa:"name=an_uuid_key"`
+	UUIDKey       uuid.UUID `dosa:"name=an_uuid_key"`
 	StrKey        string
 	Int64Key      int64
-	UUIDV         dosav2.UUID
+	UUIDV         uuid.UUID
 	StrV          string
 	Int64V        int64 `dosa:"name=an_int64_value"`
 	Int32V        int32

--- a/testentity/testentity.go
+++ b/testentity/testentity.go
@@ -23,16 +23,17 @@ package testentity
 import (
 	"time"
 
+	satori "github.com/satori/go.uuid"
 	"github.com/uber-go/dosa"
 )
 
 // TestEntity uses common key types and all types in value fields.
 type TestEntity struct {
 	dosa.Entity `dosa:"name=awesome_test_entity, primaryKey=(UUIDKey, StrKey ASC, Int64Key DESC)"`
-	UUIDKey     dosa.UUID `dosa:"name=an_uuid_key"`
+	UUIDKey     satori.UUID `dosa:"name=an_uuid_key"`
 	StrKey      string
 	Int64Key    int64
-	UUIDV       dosa.UUID
+	UUIDV       satori.UUID
 	StrV        string
 	Int64V      int64 `dosa:"name=an_int64_value"`
 	Int32V      int32
@@ -41,7 +42,7 @@ type TestEntity struct {
 	BlobV       []byte
 	TSV         time.Time
 
-	UUIDVP   *dosa.UUID
+	UUIDVP   *satori.UUID
 	StrVP    *string
 	Int64VP  *int64
 	Int32VP  *int32

--- a/testutil/generator.go
+++ b/testutil/generator.go
@@ -23,7 +23,7 @@ package testutil
 import (
 	"time"
 
-	"github.com/uber-go/dosa"
+	"github.com/satori/go.uuid"
 )
 
 // TestInt64Ptr create pointer for int64
@@ -56,8 +56,8 @@ func TestBoolPtr(b bool) *bool {
 	return &b
 }
 
-// TestUUIDPtr create pointer for dosa.UUID
-func TestUUIDPtr(b dosa.UUID) *dosa.UUID {
+// TestUUIDPtr create pointer for uuid.UUID
+func TestUUIDPtr(b uuid.UUID) *uuid.UUID {
 	return &b
 }
 
@@ -75,7 +75,7 @@ func AssertEqForPointer(fn TestAssertFn, expected interface{}, p interface{}) {
 		fn(*v, expected)
 	case *string:
 		fn(*v, expected)
-	case *dosa.UUID:
+	case *uuid.UUID:
 		fn(*v, expected)
 	case *time.Time:
 		fn(*v, expected)

--- a/type.go
+++ b/type.go
@@ -20,11 +20,6 @@
 
 package dosa
 
-import (
-	"github.com/pkg/errors"
-	"github.com/satori/go.uuid"
-)
-
 //go:generate stringer -type=Type
 
 // Type defines a data type for an entity field
@@ -34,7 +29,7 @@ const (
 	// Invalid type to be used as zero value for Type
 	Invalid Type = iota
 
-	// TUUID is different from dosa.UUID
+	// TUUID is the UUID type
 	TUUID
 
 	// String represents a string
@@ -58,34 +53,6 @@ const (
 	// Bool is a bool type
 	Bool
 )
-
-// UUID stores a string format of uuid.
-// Validation is done before saving to datastore.
-// The format of uuid used in datastore is orthogonal to the string format here.
-type UUID string
-
-// NewUUID is a helper for returning a new dosa.UUID value
-func NewUUID() UUID {
-	return UUID(uuid.NewV4().String())
-}
-
-// Bytes gets the bytes from a UUID
-func (u UUID) Bytes() ([]byte, error) {
-	id, err := uuid.FromString(string(u))
-	if err != nil {
-		return nil, errors.Wrap(err, "invalid uuid string")
-	}
-	return id.Bytes(), nil
-}
-
-// BytesToUUID creates a UUID from a byte slice
-func BytesToUUID(bs []byte) (UUID, error) {
-	id, err := uuid.FromBytes(bs)
-	if err != nil {
-		return "", errors.Wrap(err, "invalid uuid bytes")
-	}
-	return UUID(id.String()), nil
-}
 
 // FromString converts string to dosa Type
 func FromString(s string) Type {

--- a/type_test.go
+++ b/type_test.go
@@ -23,38 +23,8 @@ package dosa
 import (
 	"testing"
 
-	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestNewUUID(t *testing.T) {
-	id := NewUUID()
-	assert.NotNil(t, id)
-	assert.NotEqual(t, string(id), "")
-}
-
-func TestUUIDToBytes(t *testing.T) {
-	id := UUID(uuid.NewV4().String())
-	bs, err := id.Bytes()
-	assert.NoError(t, err)
-	assert.Len(t, bs, 16)
-
-	invalidUUID := UUID("xyz-1827380-kdwi-4829")
-	_, err = invalidUUID.Bytes()
-	assert.Error(t, err)
-}
-
-func TestBytesToUUID(t *testing.T) {
-	id := uuid.NewV4()
-	bs := id.Bytes()
-	uid, err := BytesToUUID(bs)
-	assert.NoError(t, err)
-	assert.EqualValues(t, id.String(), uid)
-
-	invalidBs := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
-	_, err = BytesToUUID(invalidBs)
-	assert.Error(t, err)
-}
 
 func TestFromString(t *testing.T) {
 	tt := []struct {


### PR DESCRIPTION
A lot of boilerplate and plumbing. Interesting bits:
 -  conversion to/from `gocql.uuid` to `satori/go.uuid.UUID` (via strings)
 - the `finder` needs to accept `uuid.UUID` as a permitted type
