### PR TITLE
Satori uuid 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ cache:
     - vendor
 
 install:
+  - go get golang.org/x/lint
   - make vendor
   - pip install --user cql PyYAML six
   - git clone --depth 1 https://github.com/pcmanus/ccm.git

--- a/connectors/cassandra/datastore_crud_test.go
+++ b/connectors/cassandra/datastore_crud_test.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	gouuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/dosa"
 )
@@ -38,7 +37,7 @@ var (
 
 func TestReadNotFound(t *testing.T) {
 	sut := GetTestConnector(t)
-	id := constructKeys(dosa.UUID(gouuid.NewV4().String()))
+	id := constructKeys(dosa.NewUUID())
 	_, err := sut.Read(context.TODO(), testEntityInfo, id, []string{int32Field})
 	assert.Error(t, err)
 	assert.IsType(t, &dosa.ErrNotFound{}, errors.Cause(err), err.Error())
@@ -46,7 +45,7 @@ func TestReadNotFound(t *testing.T) {
 
 func TestReadTimeout(t *testing.T) {
 	sut := GetTestConnector(t)
-	id := constructKeys(dosa.UUID(gouuid.NewV4().String()))
+	id := constructKeys(dosa.NewUUID())
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Microsecond)
 	defer cancel()
 	_, err := sut.Read(ctx, testEntityInfo, id, []string{int32Field})
@@ -56,7 +55,7 @@ func TestReadTimeout(t *testing.T) {
 
 func TestUpsertAndRead(t *testing.T) {
 	sut := GetTestConnector(t)
-	uuid := dosa.UUID(gouuid.NewV4().String())
+	uuid := dosa.NewUUID()
 	values := constructFullValues(uuid)
 	err := sut.Upsert(context.TODO(), testEntityInfo, values)
 	assert.NoError(t, err)
@@ -79,7 +78,7 @@ func TestUpsertAndRead(t *testing.T) {
 	}
 
 	// partial create second object
-	uuid2 := dosa.UUID(gouuid.NewV4().String())
+	uuid2 := dosa.NewUUID()
 	pc2 := map[string]dosa.FieldValue{
 		uuidKeyField:   uuid2,
 		stringKeyField: defaultStringKeyValue,
@@ -119,7 +118,7 @@ func TestUpsertAndRead(t *testing.T) {
 
 func TestCreateIfNotExists(t *testing.T) {
 	sut := GetTestConnector(t)
-	uuid := dosa.UUID(gouuid.NewV4().String())
+	uuid := dosa.NewUUID()
 	values := constructFullValues(uuid)
 	err := sut.CreateIfNotExists(context.TODO(), testEntityInfo, values)
 	assert.NoError(t, err)
@@ -141,7 +140,7 @@ func TestCreateIfNotExists(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	sut := GetTestConnector(t)
-	uuid1 := dosa.UUID(gouuid.NewV4().String())
+	uuid1 := dosa.NewUUID()
 	id1 := constructKeys(uuid1)
 	v1 := constructFullValues(uuid1)
 
@@ -165,7 +164,7 @@ func TestDelete(t *testing.T) {
 
 func TestRemoveRange(t *testing.T) {
 	sut := GetTestConnector(t)
-	uuid1 := dosa.UUID(gouuid.NewV4().String())
+	uuid1 := dosa.NewUUID()
 	v1 := constructFullValues(uuid1)
 	v1[int64KeyField] = 1
 	v2 := constructFullValues(uuid1)
@@ -246,7 +245,7 @@ func constructFullValues(uuid dosa.UUID) map[string]dosa.FieldValue {
 		// Anything smaller than ms is lost.
 		timestampField: time.Unix(100, 111000000).UTC(),
 		stringField:    "appleV",
-		uuidField:      dosa.UUID(gouuid.NewV4().String()),
+		uuidField:      dosa.NewUUID(),
 	}
 }
 

--- a/connectors/cassandra/datastore_query_test.go
+++ b/connectors/cassandra/datastore_query_test.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"testing"
 
-	gouuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/dosa"
 )
@@ -37,7 +36,7 @@ var (
 
 func TestRangeQuery(t *testing.T) {
 	sut := GetTestConnector(t)
-	partitionKey := dosa.UUID(gouuid.NewV4().String())
+	partitionKey := dosa.NewUUID()
 	populateEntityRange(t, partitionKey)
 
 	var (
@@ -102,7 +101,7 @@ func TestRangeQuery(t *testing.T) {
 func TestRangeQueryInvalidToken(t *testing.T) {
 	sut := GetTestConnector(t)
 	_, _, err := sut.Range(context.TODO(), testEntityInfo, map[string][]*dosa.Condition{
-		uuidKeyField: {{Op: dosa.Eq, Value: dosa.UUID(gouuid.NewV4().String())}},
+		uuidKeyField: {{Op: dosa.Eq, Value: dosa.NewUUID()}},
 	}, []string{int32Field}, "西瓜", pageSize)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "bad token")
@@ -110,7 +109,7 @@ func TestRangeQueryInvalidToken(t *testing.T) {
 
 func TestRangeQueryFieldsToRead(t *testing.T) {
 	sut := GetTestConnector(t)
-	partitionKey := dosa.UUID(gouuid.NewV4().String())
+	partitionKey := dosa.NewUUID()
 	populateEntityRange(t, partitionKey)
 
 	res, token, err := sut.Range(context.TODO(), testEntityInfo, map[string][]*dosa.Condition{
@@ -150,7 +149,7 @@ func TestScan(t *testing.T) {
 	}
 
 	for i := 0; i < 100; i++ {
-		id := dosa.UUID(gouuid.NewV4().String())
+		id := dosa.NewUUID()
 		expectedUUIDSet[id] = struct{}{}
 		expectedIntValueSet[i] = struct{}{}
 		err := sut.Upsert(context.TODO(), entityInfo, map[string]dosa.FieldValue{

--- a/connectors/memory/memory_test.go
+++ b/connectors/memory/memory_test.go
@@ -1196,23 +1196,23 @@ func TestCompoundPartSecondaryIndex(t *testing.T) {
 	bucketID := 1
 	now := time.Now()
 
-	repoUUID0 := uuid.NewV4().String()
+	repoUUID0 := dosa.NewUUID()
 	createdAt0 := now.Add(-1 * time.Hour)
 	result0 := 5
 
 	err := sut.Upsert(context.TODO(), compoundPartEi, map[string]dosa.FieldValue{
-		"RepositoryUUID": dosa.FieldValue(dosa.UUID(repoUUID0)),
+		"RepositoryUUID": dosa.FieldValue(repoUUID0),
 		"BucketID":       dosa.FieldValue(int32(bucketID)),
 		"CreatedAt":      dosa.FieldValue(createdAt0),
 		"Result":         dosa.FieldValue(int32(result0)),
 	})
 
-	repoUUID1 := uuid.NewV4().String()
+	repoUUID1 := dosa.NewUUID()
 	createdAt1 := now.Add(-2 * time.Hour)
 	result1 := 4
 
 	err = sut.Upsert(context.TODO(), compoundPartEi, map[string]dosa.FieldValue{
-		"RepositoryUUID": dosa.FieldValue(dosa.UUID(repoUUID1)),
+		"RepositoryUUID": dosa.FieldValue(repoUUID1),
 		"BucketID":       dosa.FieldValue(int32(bucketID)),
 		"CreatedAt":      dosa.FieldValue(createdAt1),
 		"Result":         dosa.FieldValue(int32(result1)),

--- a/connectors/random/random.go
+++ b/connectors/random/random.go
@@ -26,7 +26,6 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/satori/go.uuid"
 	"github.com/uber-go/dosa"
 )
 
@@ -86,7 +85,7 @@ func Data(ei *dosa.EntityInfo, minimumFields []string) map[string]dosa.FieldValu
 		case dosa.Timestamp:
 			v = dosa.FieldValue(time.Unix(0, rand.Int63()/2))
 		case dosa.TUUID:
-			v = dosa.FieldValue(uuid.NewV4())
+			v = dosa.FieldValue(dosa.NewUUID())
 		default:
 			panic("invalid type " + cd.Type.String())
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 8b504c7412567ab097019fc80fff8dc43647b3247180549699dcadd3d57244e8
-updated: 2018-04-06T14:54:41.617824-07:00
+hash: 9460488878f921a42a216a88ee71d37ba56e6bf16a251b258dd89a0701267c0a
+updated: 2018-04-26T11:11:33.609139-07:00
 imports:
 - name: github.com/beorn7/perks
-  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  version: 3a771d992973f24aa725d07868b467d1ddfceafb
   subpackages:
   - quantile
 - name: github.com/elodina/go-avro
@@ -15,7 +15,7 @@ imports:
   - internal
   - redis
 - name: github.com/gobwas/glob
-  version: 51eb1ee00b6d931c66d229ceeb7c31b985563420
+  version: f00a7392b43971b2fdb562418faab1f18da2067a
   subpackages:
   - compiler
   - match
@@ -35,7 +35,7 @@ imports:
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
-  version: 925541529c1fa6821df4e44ce2723319eb2be768
+  version: e09c5db296004fbe3f74490e84dcd62c3c5ddb1b
   subpackages:
   - proto
 - name: github.com/golang/snappy
@@ -65,13 +65,13 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 2f17f4a9d485bf34b4bfaccc273805040e4f86c8
+  version: d811d2e9bf898806ecfb6ef6296774b13ffc314c
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: cb4147076ac75738c9a7d279075a253c0cc5acbd
+  version: 8b1c2da0d56deffdbb9e48d4414b4e674bd8083e
   subpackages:
   - internal/util
   - nfs
@@ -162,7 +162,7 @@ imports:
   - yarpcconfig
   - yarpcerrors
 - name: go.uber.org/zap
-  version: 35aad584952c3e7020db7b839f6b102de6271f89
+  version: eeedf312bc6c57391d84767a4cd413f02a917974
   subpackages:
   - buffer
   - internal/bufferpool
@@ -170,7 +170,7 @@ imports:
   - internal/exit
   - zapcore
 - name: golang.org/x/net
-  version: b3c676e531a6dc479fa1b35ac961c13f5e2b4d2e
+  version: 5f9ae10d9af5b1c89ae6904293b14b064d4ada23
   subpackages:
   - bpf
   - context
@@ -179,9 +179,9 @@ imports:
   - ipv4
   - ipv6
 - name: gopkg.in/inf.v0
-  version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
+  version: d2d2541c53f18d2a059457998ce2876cc8e67cbf
 - name: gopkg.in/yaml.v2
-  version: d670f9405373e636a5a2765eea47fac0c9bc91a4
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 testImports:
 - name: github.com/anmitsu/go-shlex
   version: 648efa622239a2f6ff949fed78ee37b48d499ba4
@@ -190,23 +190,23 @@ testImports:
   subpackages:
   - gocov
 - name: github.com/davecgh/go-spew
-  version: 346938d642f2ec3594ed81d874461961cd0faa76
+  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
   subpackages:
   - spew
 - name: github.com/go-playground/overalls
-  version: b472d5a5b9424bffa8444021b47d1b7b4c894b23
+  version: 22ec1a223b7c9a2e56355bd500b539cba3784238
 - name: github.com/golang/lint
-  version: e14d9b0f1d332b1420c1ffa32562ad2dc84d645d
+  version: 1fb4e4796c08a9a18d8796a6aed584bf4b346bc9
   subpackages:
   - golint
 - name: github.com/kisielk/errcheck
-  version: b1445a9dd8285a50c6d1661d16f0a9ceb08125f7
+  version: 8050dd7cc11578becd8622667107bb21a7baf451
 - name: github.com/kisielk/gotool
-  version: d6ce6262d87e3a4e153e86023ff56ae771554a41
+  version: 80517062f582ea3340cd4baf70e86d539ae7d84d
 - name: github.com/matm/gocov-html
   version: f6dd0fd0ebc7c8cff8b24c0a585caeef250627a3
 - name: github.com/mattn/goveralls
-  version: b71a1e4855f87991aff01c2c833a75a07059c61c
+  version: 1c14a4061c1cb86f0310cc0d4c0b5bc743879bc5
 - name: github.com/pmezard/go-difflib
   version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
@@ -224,6 +224,6 @@ testImports:
 - name: github.com/yookoala/realpath
   version: d19ef9c409d9817c1e685775e53d361b03eabbc8
 - name: golang.org/x/tools
-  version: 25101aadb97aa42907eee6a238d6d26a6cb3c756
+  version: c1def519f03ddf76f16b3e444ee1095d73afa01b
   subpackages:
   - cover

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 9460488878f921a42a216a88ee71d37ba56e6bf16a251b258dd89a0701267c0a
-updated: 2018-04-26T11:11:33.609139-07:00
+updated: 2018-04-26T11:56:35.133928-07:00
 imports:
 - name: github.com/beorn7/perks
   version: 3a771d992973f24aa725d07868b467d1ddfceafb
@@ -212,7 +212,7 @@ testImports:
   subpackages:
   - difflib
 - name: github.com/russross/blackfriday
-  version: c455fd41c6baf2f78fd7ff0aadc4e4b4d52698b0
+  version: 6aeb241ce2c0d259208d56810fc8831a46df5660
 - name: github.com/sectioneight/md-to-godoc
   version: 79157ff08f1acd5c5b1d13d71c0adb7908dbb8a2
 - name: github.com/shurcooL/sanitized_anchor_name

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,7 +10,7 @@ import:
 - package: github.com/pkg/errors
   version: ^0.8.0
 - package: github.com/satori/go.uuid
-  version: ^1.1.0
+  version: ^1.2
 - package: github.com/uber/dosa-idl
   version: ttl-for-multi-upsert
   subpackages:

--- a/type.go
+++ b/type.go
@@ -66,6 +66,7 @@ type UUID string
 
 // NewUUID is a helper for returning a new dosa.UUID value
 func NewUUID() UUID {
+	// return UUID(uuid.Must(uuid.NewV4()).String())
 	return UUID(uuid.NewV4().String())
 }
 

--- a/type_test.go
+++ b/type_test.go
@@ -49,7 +49,7 @@ func TestBytesToUUID(t *testing.T) {
 	assert.NoError(t, err0)
 	uid, err := BytesToUUID(bs)
 	assert.NoError(t, err)
-	assert.EqualValues(t, string(id), uid)
+	assert.EqualValues(t, id, uid)
 
 	invalidBs := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 	_, err = BytesToUUID(invalidBs)

--- a/type_test.go
+++ b/type_test.go
@@ -23,7 +23,6 @@ package dosa
 import (
 	"testing"
 
-	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,7 +33,7 @@ func TestNewUUID(t *testing.T) {
 }
 
 func TestUUIDToBytes(t *testing.T) {
-	id := UUID(uuid.NewV4().String())
+	id := NewUUID()
 	bs, err := id.Bytes()
 	assert.NoError(t, err)
 	assert.Len(t, bs, 16)
@@ -45,11 +44,12 @@ func TestUUIDToBytes(t *testing.T) {
 }
 
 func TestBytesToUUID(t *testing.T) {
-	id := uuid.NewV4()
-	bs := id.Bytes()
+	id := NewUUID()
+	bs, err0 := id.Bytes()
+	assert.NoError(t, err0)
 	uid, err := BytesToUUID(bs)
 	assert.NoError(t, err)
-	assert.EqualValues(t, id.String(), uid)
+	assert.EqualValues(t, string(id), uid)
 
 	invalidBs := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 	_, err = BytesToUUID(invalidBs)


### PR DESCRIPTION
Also cleanup: replace all calls to `uuid.NewV4().String()` with `dosa.NewUUID()` to keep the call to the breaking function in one place.