### PR TITLE
Glide cleanup

### DIFF
--- a/.build/deps.mk
+++ b/.build/deps.mk
@@ -12,7 +12,7 @@ deps: libdeps
 	$(ECHO_V)go install ./vendor/github.com/mattn/goveralls
 	$(ECHO_V)go install ./vendor/github.com/go-playground/overalls
 	@$(call label,Installing golint...)
-	$(ECHO_V)go install ./vendor/github.com/golang/lint/golint
+	$(ECHO_V)go install ./vendor/golang.org/x/lint/golint
 	@$(call label,Installing errcheck...)
 	$(ECHO_V)go install ./vendor/github.com/kisielk/errcheck
 	@$(call label,Installing md-to-godoc...)

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ cache:
     - vendor
 
 install:
-  - go get golang.org/x/lint
   - make vendor
   - pip install --user cql PyYAML six
   - git clone --depth 1 https://github.com/pcmanus/ccm.git

--- a/connectors/redis/redis_test.go
+++ b/connectors/redis/redis_test.go
@@ -21,6 +21,7 @@
 package redis_test
 
 import (
+	"context"
 	"math/rand"
 	"testing"
 	"time"
@@ -31,7 +32,6 @@ import (
 	"github.com/uber-go/dosa/connectors/redis"
 	"github.com/uber-go/dosa/mocks"
 	"github.com/uber-go/dosa/testentity"
-	"golang.org/x/net/context"
 )
 
 var testRedisConfig = redis.Config{

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: cccbedcb0d49497dc1554b060ad36525fc742509d5fe0c0e3bf245b89514cb7c
-updated: 2018-04-30T16:28:57.741954-07:00
+hash: 74fb1a80e13e9dde3d063c0b1355a20e322fc5ced16a4315a9760500ab9535fe
+updated: 2018-04-30T17:07:54.140953-07:00
 imports:
 - name: github.com/beorn7/perks
   version: 3a771d992973f24aa725d07868b467d1ddfceafb
@@ -25,7 +25,7 @@ imports:
   - util/runes
   - util/strings
 - name: github.com/gocql/gocql
-  version: 4ba1af8a026b230ce3c646e594865c07ce01b541
+  version: 33a5f3c1bcc2c421b3221c5858312afb141bf605
   subpackages:
   - internal/lru
   - internal/murmur

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b9024db84ba5f6f53cbab20be8c4d1bc384ea5abf7a26effc3fd031034a5f071
-updated: 2018-04-30T16:01:57.675938-07:00
+hash: cccbedcb0d49497dc1554b060ad36525fc742509d5fe0c0e3bf245b89514cb7c
+updated: 2018-04-30T16:28:57.741954-07:00
 imports:
 - name: github.com/beorn7/perks
   version: 3a771d992973f24aa725d07868b467d1ddfceafb
@@ -217,3 +217,7 @@ testImports:
   version: 470b6b0bb3005eda157f0275e2e4895055396a81
   subpackages:
   - golint
+- name: golang.org/x/tools
+  version: 165bdd618e6d174c61ee7bd73a28f3e5c6fdced1
+  subpackages:
+  - cover

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d7b9c315ea81c7388a4707ca9a852d8d914b0437e1d7aabbea50cda29c0b3bd2
-updated: 2018-04-26T13:15:16.630472-07:00
+hash: 93ecf41ca94a83edfe97516d014de053879b778b80d1c16779de6f6325ba715e
+updated: 2018-04-30T15:34:03.427828-07:00
 imports:
 - name: github.com/beorn7/perks
   version: 3a771d992973f24aa725d07868b467d1ddfceafb
@@ -10,12 +10,12 @@ imports:
 - name: github.com/facebookgo/clock
   version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
 - name: github.com/garyburd/redigo
-  version: 433969511232c397de61b1442f9fd49ec06ae9ba
+  version: a69d19351219b6dd56f274f96d85a7014a2ec34e
   subpackages:
   - internal
   - redis
 - name: github.com/gobwas/glob
-  version: f00a7392b43971b2fdb562418faab1f18da2067a
+  version: 5ccd90ef52e1e632236f7326478d4faa74f99438
   subpackages:
   - compiler
   - match
@@ -31,7 +31,7 @@ imports:
   - internal/murmur
   - internal/streams
 - name: github.com/golang/mock
-  version: 8b2eeeb0ca5f56c78bec5efde9c4a21d9201126c
+  version: c34cdb4725f4c3844d095133c6e40e448b86589b
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
@@ -183,8 +183,6 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 testImports:
-- name: github.com/anmitsu/go-shlex
-  version: 648efa622239a2f6ff949fed78ee37b48d499ba4
 - name: github.com/axw/gocov
   version: 3a69a0d2a4ef1f263e2d92b041a69593d6964fe8
   subpackages:
@@ -195,14 +193,8 @@ testImports:
   - spew
 - name: github.com/go-playground/overalls
   version: 22ec1a223b7c9a2e56355bd500b539cba3784238
-- name: github.com/golang/lint
-  version: 1fb4e4796c08a9a18d8796a6aed584bf4b346bc9
-  subpackages:
-  - golint
 - name: github.com/kisielk/errcheck
   version: 8050dd7cc11578becd8622667107bb21a7baf451
-- name: github.com/kisielk/gotool
-  version: 80517062f582ea3340cd4baf70e86d539ae7d84d
 - name: github.com/matm/gocov-html
   version: f6dd0fd0ebc7c8cff8b24c0a585caeef250627a3
 - name: github.com/mattn/goveralls
@@ -211,19 +203,15 @@ testImports:
   version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
-- name: github.com/russross/blackfriday
-  version: 6aeb241ce2c0d259208d56810fc8831a46df5660
 - name: github.com/sectioneight/md-to-godoc
   version: 79157ff08f1acd5c5b1d13d71c0adb7908dbb8a2
-- name: github.com/shurcooL/sanitized_anchor_name
-  version: 86672fcb3f950f35f2e675df2240550f2a50762f
 - name: github.com/stretchr/testify
   version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
   subpackages:
   - assert
 - name: github.com/yookoala/realpath
   version: d19ef9c409d9817c1e685775e53d361b03eabbc8
-- name: golang.org/x/tools
-  version: 6e0e2181b9b7327c20fd9aa37d42a9515169a418
+- name: golang.org/x/lint
+  version: 470b6b0bb3005eda157f0275e2e4895055396a81
   subpackages:
-  - cover
+  - golint

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 93ecf41ca94a83edfe97516d014de053879b778b80d1c16779de6f6325ba715e
-updated: 2018-04-30T15:34:03.427828-07:00
+hash: b9024db84ba5f6f53cbab20be8c4d1bc384ea5abf7a26effc3fd031034a5f071
+updated: 2018-04-30T16:01:57.675938-07:00
 imports:
 - name: github.com/beorn7/perks
   version: 3a771d992973f24aa725d07868b467d1ddfceafb
@@ -25,7 +25,7 @@ imports:
   - util/runes
   - util/strings
 - name: github.com/gocql/gocql
-  version: 33a5f3c1bcc2c421b3221c5858312afb141bf605
+  version: 4ba1af8a026b230ce3c646e594865c07ce01b541
   subpackages:
   - internal/lru
   - internal/murmur
@@ -35,7 +35,7 @@ imports:
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
-  version: e09c5db296004fbe3f74490e84dcd62c3c5ddb1b
+  version: b4deda0973fb4c70b50d226b1af49f3da59f5265
   subpackages:
   - proto
 - name: github.com/golang/snappy
@@ -195,6 +195,8 @@ testImports:
   version: 22ec1a223b7c9a2e56355bd500b539cba3784238
 - name: github.com/kisielk/errcheck
   version: 8050dd7cc11578becd8622667107bb21a7baf451
+- name: github.com/kisielk/gotool
+  version: 80517062f582ea3340cd4baf70e86d539ae7d84d
 - name: github.com/matm/gocov-html
   version: f6dd0fd0ebc7c8cff8b24c0a585caeef250627a3
 - name: github.com/mattn/goveralls

--- a/glide.yaml
+++ b/glide.yaml
@@ -55,3 +55,4 @@ testImport:
 - package: github.com/kisielk/gotool
 - package: github.com/sectioneight/md-to-godoc
 - package: github.com/yookoala/realpath
+- package: golang.org/x/tools/cover

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,6 +8,8 @@ import:
 - package: github.com/gobwas/glob
   version: ^0.2.3
 - package: github.com/gocql/gocql
+  # Fix gocql version until we confirm this issue has been resolved: https://github.com/gocql/gocql/issues/1050
+  version: 33a5f3c1bcc2c421b3221c5858312afb141bf605
 - package: github.com/golang/mock
   version: ^1.1.1
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -19,6 +19,7 @@ import:
 - package: github.com/satori/go.uuid
   version: ^1.2.0
 - package: github.com/uber/dosa-idl
+  version: f3fe9986ab26bd2f262f61fdcee60990bd9b6abc
   subpackages:
   - .gen/dosa
   - .gen/dosa/dosaclient
@@ -51,5 +52,6 @@ testImport:
   subpackages:
     - golint
 - package: github.com/kisielk/errcheck
+- package: github.com/kisielk/gotool
 - package: github.com/sectioneight/md-to-godoc
 - package: github.com/yookoala/realpath

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,59 +1,55 @@
 package: github.com/uber-go/dosa
 import:
 - package: github.com/elodina/go-avro
+- package: github.com/garyburd/redigo
+  version: ^1.6.0
+  subpackages:
+  - redis
+- package: github.com/gobwas/glob
+  version: ^0.2.3
+- package: github.com/gocql/gocql
 - package: github.com/golang/mock
-  version: master
+  version: ^1.1.1
   subpackages:
   - gomock
 - package: github.com/jessevdk/go-flags
-  version: ^1.2.0
+  version: ^1.4.0
 - package: github.com/pkg/errors
   version: ^0.8.0
 - package: github.com/satori/go.uuid
-  version: ^1.2
+  version: ^1.2.0
 - package: github.com/uber/dosa-idl
-  version: f3fe9986ab26bd2f262f61fdcee60990bd9b6abc
   subpackages:
   - .gen/dosa
   - .gen/dosa/dosaclient
 - package: go.uber.org/yarpc
-  version: ^1.7.1
+  version: ^1.29.1
   subpackages:
   - api/transport
   - transport/http
   - transport/tchannel
-- package: github.com/gobwas/glob
-- package: github.com/gocql/gocql
-  # Fix gocql version until we confirm this issue has been resolved: https://github.com/gocql/gocql/issues/1050
-  version: 33a5f3c1bcc2c421b3221c5858312afb141bf605
-- package: github.com/garyburd/redigo
-  version: ~1.1.0
-  subpackages:
-  - redis
+- package: gopkg.in/yaml.v2
+  version: ^2.2.1
 testImport:
-- package: github.com/yookoala/realpath
 - package: github.com/stretchr/testify
-  version: ^1.1.4
+  version: ^1.2.1
   subpackages:
   - assert
-- package: golang.org/x/tools
-  subpackages:
-  - cover
-- package: github.com/anmitsu/go-shlex
-- package: github.com/mattn/goveralls
-- package: github.com/golang/lint
-  subpackages:
-  - golint
-- package: github.com/kisielk/gotool
-- package: github.com/kisielk/errcheck
+- package: github.com/uber/tchannel-go
+  version: ^1
+
+# The following packages are needed soley for build and test 
+# reporting related things. None of our actual code (including 
+# out tests) depends on these packages.
 - package: github.com/axw/gocov
   subpackages:
-  - gocov
+    - gocov
 - package: github.com/matm/gocov-html
+- package: github.com/mattn/goveralls
 - package: github.com/go-playground/overalls
+- package: golang.org/x/lint
+  subpackages:
+    - golint
+- package: github.com/kisielk/errcheck
 - package: github.com/sectioneight/md-to-godoc
-  version: master
-- package: github.com/russross/blackfriday
-  version: "2"
-- package: github.com/shurcooL/sanitized_anchor_name
-- package: gopkg.in/yaml.v2
+- package: github.com/yookoala/realpath

--- a/mocks/client.go
+++ b/mocks/client.go
@@ -6,9 +6,10 @@ package mocks
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	dosa "github.com/uber-go/dosa"
-	reflect "reflect"
 )
 
 // MockClient is a mock of Client interface


### PR DESCRIPTION
This is a large scale cleanup of our glide.yaml file. We remove a bunch of packages we don't need anymore, and clean up a little code related to packages that we actually didn't need. We also organize all of the packages we're bringing in that are purely related to build infrastructure (and not actually needed for building of the code).