### PR TITLE
remove unused fields on RegisteredEntity

### DIFF
--- a/registrar.go
+++ b/registrar.go
@@ -30,23 +30,17 @@ import (
 // performing operations on an entity as well as helper methods for accessing
 // type data so that reflection can be minimized.
 type RegisteredEntity struct {
-	scope      string
-	namePrefix string
-	table      *Table
-	version    int32
-	schemaRef  *SchemaRef
-	typ        reflect.Type // optimization to avoid doing repetitive reflect.TypeOf
+	table     *Table
+	schemaRef *SchemaRef
 }
 
 // NewRegisteredEntity is a constructor for creating a RegisteredEntity
-func NewRegisteredEntity(scope, prefix string, table *Table) *RegisteredEntity {
+func NewRegisteredEntity(scope, namePrefix string, table *Table) *RegisteredEntity {
 	return &RegisteredEntity{
-		scope:      scope,
-		namePrefix: prefix,
-		table:      table,
+		table: table,
 		schemaRef: &SchemaRef{
 			Scope:      scope,
-			NamePrefix: prefix,
+			NamePrefix: namePrefix,
 			EntityName: table.Name,
 		},
 	}


### PR DESCRIPTION
There are several fields on `RegisteredEntity` that are completely unused. There is no code anywhere that uses these fields anywhere and they are private fields so nobody else could be using them. This is completely dead code that serves no purpose. Let's get rid of it.