### PR TITLE
remove notions of FQNs

### DIFF
--- a/names.go
+++ b/names.go
@@ -21,49 +21,32 @@
 package dosa
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
 )
 
 const (
-	fqnSeparator = "."
-	rootFQN      = FQN("")
-	maxNameLen   = 32
+	maxNameLen = 32
 )
 
-// FQN is the fully qualified name for an entity
-type FQN string
+var (
+	namePrefixRegex = regexp.MustCompile("^[a-z_][a-z0-9_.]{0,31}$")
+)
 
-// String satisfies fmt.Stringer interface
-func (f FQN) String() string {
-	return string(f)
-}
-
-// Child returns a new child FQN with the given comp at the end
-func (f FQN) Child(s string) (FQN, error) {
-	comp, err := NormalizeName(s)
-	if err != nil {
-		return "", errors.Wrap(err, "cannot create child FQN")
+// IsValidNamePrefix ensures the given prefix is ok.
+func IsValidNamePrefix(namePrefix string) error {
+	normalized := strings.ToLower(strings.TrimSpace(namePrefix))
+	if !namePrefixRegex.MatchString(normalized) {
+		return errors.Errorf("Name Prefix %s is invalid. It was normalized to "+
+			"%s which means it does not pass the regex %s",
+			namePrefix,
+			normalized,
+			namePrefixRegex.String(),
+		)
 	}
-	return FQN(strings.Join([]string{string(f), comp}, fqnSeparator)), nil
-}
-
-// ToFQN converts the input string to FQN
-func ToFQN(s string) (FQN, error) {
-	if s == "" {
-		return rootFQN, nil
-	}
-	comps := strings.Split(s, fqnSeparator)
-	normalizedComps := make([]string, len(comps))
-	for i, c := range comps {
-		comp, err := NormalizeName(c)
-		if err != nil {
-			return "", errors.Wrap(err, "cannot create FQN with invalid name component")
-		}
-		normalizedComps[i] = comp
-	}
-	return FQN(strings.Join(normalizedComps, fqnSeparator)), nil
+	return nil
 }
 
 func isInvalidFirstRune(r rune) bool {

--- a/names_test.go
+++ b/names_test.go
@@ -130,40 +130,22 @@ func TestNormalizeName(t *testing.T) {
 	}
 }
 
-func TestToFQN(t *testing.T) {
-	f, err := dosa.ToFQN("service.foo")
+func TestIsValidNamePrefix(t *testing.T) {
+	err := dosa.IsValidNamePrefix("service.foo")
 	assert.NoError(t, err)
-	assert.EqualValues(t, "service.foo", f)
 
-	f, err = dosa.ToFQN("MyService.Foo.V2")
+	err = dosa.IsValidNamePrefix("MyService.Foo.V2")
 	assert.NoError(t, err)
-	assert.EqualValues(t, "myservice.foo.v2", f)
 
-	f, err = dosa.ToFQN("")
-	assert.NoError(t, err)
-	assert.EqualValues(t, "", f)
-
-	_, err = dosa.ToFQN("service.an entity")
+	err = dosa.IsValidNamePrefix("")
 	assert.Error(t, err)
 
-	_, err = dosa.ToFQN("germanRush.über")
+	err = dosa.IsValidNamePrefix("service.an entity")
 	assert.Error(t, err)
-}
 
-func TestFQNChild(t *testing.T) {
-	fqn, err := dosa.ToFQN("foo.bar")
-	assert.NoError(t, err)
-
-	c, err := fqn.Child("qux")
-	assert.NoError(t, err)
-	assert.EqualValues(t, "foo.bar.qux", c)
-
-	_, err = fqn.Child("世界")
+	err = dosa.IsValidNamePrefix("germanRush.über")
 	assert.Error(t, err)
-}
 
-func TestFQNStringer(t *testing.T) {
-	fqn, err := dosa.ToFQN("foo.bar")
-	assert.NoError(t, err)
-	assert.Equal(t, "foo.bar", fqn.String())
+	err = dosa.IsValidNamePrefix("this.prefix.has.more.than.thrity.two.characters.in.it")
+	assert.Error(t, err)
 }

--- a/registrar.go
+++ b/registrar.go
@@ -219,8 +219,7 @@ type prefixedRegistrar struct {
 // and prefix to uniquely identify where entities should live but the
 // registrar itself is only responsible for basic accounting of entities.
 func NewRegistrar(scope, namePrefix string, entities ...DomainObject) (Registrar, error) {
-	_, err := ToFQN(namePrefix)
-	if err != nil {
+	if err := IsValidNamePrefix(namePrefix); err != nil {
 		return nil, errors.Wrap(err, "failed to construct Registrar")
 	}
 	typeIndex := make(map[reflect.Type]*RegisteredEntity)

--- a/schema/avro/avro.go
+++ b/schema/avro/avro.go
@@ -132,7 +132,7 @@ func (s *Field) MarshalJSON() ([]byte, error) {
 }
 
 // ToAvro converts dosa entity definition to avro schema
-func ToAvro(fqn dosa.FQN, ed *dosa.EntityDefinition) ([]byte, error) {
+func ToAvro(namePrefix string, ed *dosa.EntityDefinition) ([]byte, error) {
 	fields := make([]*Field, len(ed.Columns))
 	for i, c := range ed.Columns {
 		props := make(map[string]string)
@@ -153,7 +153,7 @@ func ToAvro(fqn dosa.FQN, ed *dosa.EntityDefinition) ([]byte, error) {
 
 	ar := &Record{
 		Name:       ed.Name,
-		Namespace:  fqn.String(),
+		Namespace:  namePrefix,
 		Fields:     fields,
 		Properties: meta,
 	}

--- a/schema/avro/avro_test.go
+++ b/schema/avro/avro_test.go
@@ -93,9 +93,8 @@ func createEntityDefinition() *dosa.EntityDefinition {
 
 func TestToAvroSchema(t *testing.T) {
 	ed := createEntityDefinition()
-	fqn, err := dosa.ToFQN("xxx.tt.yy")
-	assert.NoError(t, err)
-	av, err := ToAvro(fqn, ed)
+	namePrefix := "xxx.tt.yy"
+	av, err := ToAvro(namePrefix, ed)
 	assert.NoError(t, err)
 	ed1, err := FromAvro(string(av))
 	assert.NoError(t, err)


### PR DESCRIPTION
FQNs are a hold over from DOSA V1. We don't really use them anymore. Let's clean up some code here in the client and remove the notion of them. Let's also add a few more tests to ensure that we're only ever accepting valid name prefixes.