### PR TITLE
change default admin scope

### DIFF
--- a/client.go
+++ b/client.go
@@ -46,15 +46,12 @@
 package dosa
 
 import (
+	"bytes"
 	"context"
 	"fmt"
-	"os"
-	"reflect"
-	"strings"
-	"time"
-
-	"bytes"
 	"io"
+	"reflect"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -630,7 +627,7 @@ type adminClient struct {
 // NewAdminClient returns a new DOSA admin client for the connector provided.
 func NewAdminClient(conn Connector) AdminClient {
 	return &adminClient{
-		scope:     strings.ToLower(os.Getenv("USER")),
+		scope:     "default",
 		dirs:      []string{"."},
 		excludes:  []string{"_test.go"},
 		connector: conn,


### PR DESCRIPTION
When creating a default admin client, the scope the client uses defaults to the user's username. However, there are some usernames (e.g. `kurtis.nusbaum` which has an illegal `.`) that are not valid scope names.

In most cases this is not a problem because most CLI operations (the only thing that uses the admin client) require the user to manually specify a scope name and they usually specify a valid scope name. However, when running the `dosa schema dump <filepath>` command, there's no way for the user to specify scope (and it doesn't really make sense for them to specify one either). In such a case, when the user tries to dump their schema, they will get an error saying they're using an invalid scope name.

Let's change the default scope name to a known, valid scope. That way schema dumps will always succeed.