### PR TITLE
add GetEntitySchema to connector interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Convert usernaems to lowercase when constructing scope names etc. (#322)
 - Initial support for Adaptive Rate Limits.
 - Many accidentally exported names have been unexported. (#327)
+- Add new GetEntitySchema function to the Connector interface (#335)
 
 ## v2.6.0 (2018-04-16)
 - Fix bug in invalidating fallback cache on upsert (#292)

--- a/connector.go
+++ b/connector.go
@@ -189,6 +189,8 @@ type Connector interface {
 	UpsertSchema(ctx context.Context, scope string, namePrefix string, ed []*EntityDefinition) (status *SchemaStatus, err error)
 	// CheckSchemaStatus checks the status of the schema whether it is accepted or in progress of application.
 	CheckSchemaStatus(ctx context.Context, scope string, namePrefix string, version int32) (*SchemaStatus, error)
+	// GetEntitySchema returns the entity info for a given entity in a given scope and prefix.
+	GetEntitySchema(ctx context.Context, scope, namePrefix, entityName string, version int32) (*EntityInfo, error)
 
 	// Datastore management
 	// CreateScope creates a scope for storage of data, usually implemented by a keyspace for this data

--- a/connectors/base/base.go
+++ b/connectors/base/base.go
@@ -167,6 +167,14 @@ func (c *Connector) CheckSchemaStatus(ctx context.Context, scope string, namePre
 	return c.Next.CheckSchemaStatus(ctx, scope, namePrefix, version)
 }
 
+// GetEntitySchema calls next
+func (c *Connector) GetEntitySchema(ctx context.Context, scope, namePrefix, entityName string, version int32) (*dosa.EntityInfo, error) {
+	if c.Next == nil {
+		return nil, NewErrNoMoreConnector()
+	}
+	return c.Next.GetEntitySchema(ctx, scope, namePrefix, entityName, version)
+}
+
 // CreateScope calls Next
 func (c *Connector) CreateScope(ctx context.Context, md *dosa.ScopeMetadata) error {
 	if c.Next == nil {

--- a/connectors/devnull/devnull.go
+++ b/connectors/devnull/devnull.go
@@ -115,6 +115,11 @@ func (c *Connector) CheckSchemaStatus(ctx context.Context, scope, namePrefix str
 	}, nil
 }
 
+// GetEntitySchema always returns a blank EntityInfo and no error.
+func (c *Connector) GetEntitySchema(ctx context.Context, scope, namePrefix, entityName string, version int32) (*dosa.EntityInfo, error) {
+	return &dosa.EntityInfo{}, nil
+}
+
 // CreateScope returns success
 func (c *Connector) CreateScope(ctx context.Context, _ *dosa.ScopeMetadata) error {
 	return nil

--- a/connectors/random/random.go
+++ b/connectors/random/random.go
@@ -187,6 +187,11 @@ func (c *Connector) CheckSchemaStatus(ctx context.Context, scope, namePrefix str
 	}, nil
 }
 
+// GetEntitySchema always returns a blank EntityInfo and no error.
+func (c *Connector) GetEntitySchema(ctx context.Context, scope, namePrefix, entityName string, version int32) (*dosa.EntityInfo, error) {
+	return &dosa.EntityInfo{}, nil
+}
+
 // CreateScope returns success
 func (c *Connector) CreateScope(ctx context.Context, _ *dosa.ScopeMetadata) error {
 	return nil

--- a/connectors/routing/connector.go
+++ b/connectors/routing/connector.go
@@ -211,6 +211,15 @@ func (rc *Connector) CheckSchemaStatus(ctx context.Context, scope string, namePr
 	return connector.CheckSchemaStatus(ctx, scope, namePrefix, version)
 }
 
+// GetEntitySchema calls the selected connector
+func (rc *Connector) GetEntitySchema(ctx context.Context, scope, namePrefix, entityName string, version int32) (*dosa.EntityInfo, error) {
+	connector, err := rc.getConnector(scope, namePrefix, "GetEntitySchema")
+	if err != nil {
+		return nil, err
+	}
+	return connector.GetEntitySchema(ctx, scope, namePrefix, entityName, version)
+}
+
 // CreateScope calls selected connector
 func (rc *Connector) CreateScope(ctx context.Context, md *dosa.ScopeMetadata) error {
 	// will fall to default connector

--- a/connectors/yarpc/yarpc.go
+++ b/connectors/yarpc/yarpc.go
@@ -591,6 +591,13 @@ func (c *Connector) CheckSchemaStatus(ctx context.Context, scope, namePrefix str
 	}, nil
 }
 
+// GetEntitySchema gets the schema for the specified entity.
+func (c *Connector) GetEntitySchema(ctx context.Context, scope, namePrefix, entityName string, version int32) (*dosa.EntityInfo, error) {
+	// We're not going to implement this at the moment since it's not needed. However, it could be easily
+	// implemented by adding a new method to the thrift idl
+	panic("Not implemented")
+}
+
 // CreateScope creates the scope specified
 func (c *Connector) CreateScope(ctx context.Context, md *dosa.ScopeMetadata) error {
 	bytes, err := json.Marshal(*md)

--- a/mocks/connector.go
+++ b/mocks/connector.go
@@ -130,6 +130,19 @@ func (mr *MockConnectorMockRecorder) DropScope(arg0, arg1 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DropScope", reflect.TypeOf((*MockConnector)(nil).DropScope), arg0, arg1)
 }
 
+// GetEntitySchema mocks base method
+func (m *MockConnector) GetEntitySchema(arg0 context.Context, arg1, arg2, arg3 string, arg4 int32) (*dosa.EntityInfo, error) {
+	ret := m.ctrl.Call(m, "GetEntitySchema", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(*dosa.EntityInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEntitySchema indicates an expected call of GetEntitySchema
+func (mr *MockConnectorMockRecorder) GetEntitySchema(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntitySchema", reflect.TypeOf((*MockConnector)(nil).GetEntitySchema), arg0, arg1, arg2, arg3, arg4)
+}
+
 // MultiRead mocks base method
 func (m *MockConnector) MultiRead(arg0 context.Context, arg1 *dosa.EntityInfo, arg2 []map[string]dosa.FieldValue, arg3 []string) ([]*dosa.FieldValuesOrError, error) {
 	ret := m.ctrl.Call(m, "MultiRead", arg0, arg1, arg2, arg3)


### PR DESCRIPTION
We've run into a usecase where it would be useful to query a connector for the schema of a given entity. Let's add a function to the Connector interface that allows us to do that.