### PR TITLE
Change to EntityInfo to EntityDefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Convert usernaems to lowercase when constructing scope names etc. (#322)
 - Initial support for Adaptive Rate Limits.
 - Many accidentally exported names have been unexported. (#327)
-- Add new GetEntitySchema function to the Connector interface (#335)
+- Add new GetEntitySchema function to the Connector interface (#335 and #338)
 - Remove unused PluginFunc argument from the routing connector (#337)
 
 ## v2.6.0 (2018-04-16)

--- a/connector.go
+++ b/connector.go
@@ -190,7 +190,7 @@ type Connector interface {
 	// CheckSchemaStatus checks the status of the schema whether it is accepted or in progress of application.
 	CheckSchemaStatus(ctx context.Context, scope string, namePrefix string, version int32) (*SchemaStatus, error)
 	// GetEntitySchema returns the entity info for a given entity in a given scope and prefix.
-	GetEntitySchema(ctx context.Context, scope, namePrefix, entityName string, version int32) (*EntityInfo, error)
+	GetEntitySchema(ctx context.Context, scope, namePrefix, entityName string, version int32) (*EntityDefinition, error)
 
 	// Datastore management
 	// CreateScope creates a scope for storage of data, usually implemented by a keyspace for this data

--- a/connectors/base/base.go
+++ b/connectors/base/base.go
@@ -168,7 +168,7 @@ func (c *Connector) CheckSchemaStatus(ctx context.Context, scope string, namePre
 }
 
 // GetEntitySchema calls next
-func (c *Connector) GetEntitySchema(ctx context.Context, scope, namePrefix, entityName string, version int32) (*dosa.EntityInfo, error) {
+func (c *Connector) GetEntitySchema(ctx context.Context, scope, namePrefix, entityName string, version int32) (*dosa.EntityDefinition, error) {
 	if c.Next == nil {
 		return nil, NewErrNoMoreConnector()
 	}

--- a/connectors/devnull/devnull.go
+++ b/connectors/devnull/devnull.go
@@ -116,8 +116,8 @@ func (c *Connector) CheckSchemaStatus(ctx context.Context, scope, namePrefix str
 }
 
 // GetEntitySchema always returns a blank EntityInfo and no error.
-func (c *Connector) GetEntitySchema(ctx context.Context, scope, namePrefix, entityName string, version int32) (*dosa.EntityInfo, error) {
-	return &dosa.EntityInfo{}, nil
+func (c *Connector) GetEntitySchema(ctx context.Context, scope, namePrefix, entityName string, version int32) (*dosa.EntityDefinition, error) {
+	return &dosa.EntityDefinition{}, nil
 }
 
 // CreateScope returns success

--- a/connectors/random/random.go
+++ b/connectors/random/random.go
@@ -188,8 +188,8 @@ func (c *Connector) CheckSchemaStatus(ctx context.Context, scope, namePrefix str
 }
 
 // GetEntitySchema always returns a blank EntityInfo and no error.
-func (c *Connector) GetEntitySchema(ctx context.Context, scope, namePrefix, entityName string, version int32) (*dosa.EntityInfo, error) {
-	return &dosa.EntityInfo{}, nil
+func (c *Connector) GetEntitySchema(ctx context.Context, scope, namePrefix, entityName string, version int32) (*dosa.EntityDefinition, error) {
+	return &dosa.EntityDefinition{}, nil
 }
 
 // CreateScope returns success

--- a/connectors/routing/connector.go
+++ b/connectors/routing/connector.go
@@ -188,7 +188,7 @@ func (rc *Connector) CheckSchemaStatus(ctx context.Context, scope string, namePr
 }
 
 // GetEntitySchema calls the selected connector
-func (rc *Connector) GetEntitySchema(ctx context.Context, scope, namePrefix, entityName string, version int32) (*dosa.EntityInfo, error) {
+func (rc *Connector) GetEntitySchema(ctx context.Context, scope, namePrefix, entityName string, version int32) (*dosa.EntityDefinition, error) {
 	connector, err := rc.getConnector(scope, namePrefix)
 	if err != nil {
 		return nil, err

--- a/connectors/yarpc/yarpc.go
+++ b/connectors/yarpc/yarpc.go
@@ -592,7 +592,7 @@ func (c *Connector) CheckSchemaStatus(ctx context.Context, scope, namePrefix str
 }
 
 // GetEntitySchema gets the schema for the specified entity.
-func (c *Connector) GetEntitySchema(ctx context.Context, scope, namePrefix, entityName string, version int32) (*dosa.EntityInfo, error) {
+func (c *Connector) GetEntitySchema(ctx context.Context, scope, namePrefix, entityName string, version int32) (*dosa.EntityDefinition, error) {
 	// We're not going to implement this at the moment since it's not needed. However, it could be easily
 	// implemented by adding a new method to the thrift idl
 	panic("Not implemented")

--- a/mocks/client.go
+++ b/mocks/client.go
@@ -26,9 +26,10 @@ package mocks
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	dosa "github.com/uber-go/dosa"
-	reflect "reflect"
 )
 
 // MockClient is a mock of Client interface

--- a/mocks/connector.go
+++ b/mocks/connector.go
@@ -131,9 +131,9 @@ func (mr *MockConnectorMockRecorder) DropScope(arg0, arg1 interface{}) *gomock.C
 }
 
 // GetEntitySchema mocks base method
-func (m *MockConnector) GetEntitySchema(arg0 context.Context, arg1, arg2, arg3 string, arg4 int32) (*dosa.EntityInfo, error) {
+func (m *MockConnector) GetEntitySchema(arg0 context.Context, arg1, arg2, arg3 string, arg4 int32) (*dosa.EntityDefinition, error) {
 	ret := m.ctrl.Call(m, "GetEntitySchema", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].(*dosa.EntityInfo)
+	ret0, _ := ret[0].(*dosa.EntityDefinition)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
I goofed up and used `EntityInfo` when I should have use `EntityDefinition` for the new `GetEntitySchema` function on the `Connector` interface. Let's correct that.