### PR TITLE
Add keyPrefix to the config of redis connector

### DIFF
--- a/connectors/redis/redis_test.go
+++ b/connectors/redis/redis_test.go
@@ -40,6 +40,7 @@ var testRedisConfig = redis.Config{
 		Port: redis.RedisPort,
 	},
 	TTL: 1 * time.Minute,
+	KeyPrefix: "testPrefix",
 }
 
 var (


### PR DESCRIPTION
Background: 
Redis connector is currently used in Fallback cache for eats. Recently we are going to build capacity cache using Redis. In order to avoid key collision with these two kinds of cache, I am introducing a new field - keyPrefix to Redis Connector.

The change is to append prefix only if it's set with config. It won't change any current key that is being used in redis.