### PR TITLE
Switch to gofrs/uuid

### DIFF
--- a/connectors/memory/memory.go
+++ b/connectors/memory/memory.go
@@ -24,13 +24,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/binary"
 	"sort"
 	"sync"
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"github.com/uber-go/dosa"
 	"github.com/uber-go/dosa/connectors/base"
 	"github.com/uber-go/dosa/encoding"
@@ -157,17 +156,6 @@ func copyRow(row map[string]dosa.FieldValue) map[string]dosa.FieldValue {
 	return copied
 }
 
-// This function returns the time bits from a UUID
-// You would have to scale this to nanos to make a
-// time.Time but we don't generally need that for
-// comparisons. See RFC 4122 for these bit offsets
-func timeFromUUID(u uuid.UUID) int64 {
-	low := int64(binary.BigEndian.Uint32(u[0:4]))
-	mid := int64(binary.BigEndian.Uint16(u[4:6]))
-	hi := int64((binary.BigEndian.Uint16(u[6:8]) & 0x0fff))
-	return low + (mid << 32) + (hi << 48)
-}
-
 // compareType compares a single DOSA field based on the type. This code assumes the types of each
 // of the columns are the same, or it will panic
 func compareType(d1 dosa.FieldValue, d2 dosa.FieldValue) int8 {
@@ -183,8 +171,8 @@ func compareType(d1 dosa.FieldValue, d2 dosa.FieldValue) int8 {
 		}
 		if u1.Version() == 1 {
 			// compare time UUIDs
-			t1 := timeFromUUID(u1)
-			t2 := timeFromUUID(u2)
+			t1, _ := uuid.TimestampFromV1(u1)
+			t2, _ := uuid.TimestampFromV1(u2)
 			if t1 == t2 {
 				return 0
 			}

--- a/connectors/memory/memory_test.go
+++ b/connectors/memory/memory_test.go
@@ -29,7 +29,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/dosa"
 )
@@ -858,8 +858,8 @@ func BenchmarkConnector_Read(b *testing.B) {
 
 func TestCompareType(t *testing.T) {
 	tuuid := dosa.NewUUID()
-	v1uuid := dosa.UUID(uuid.NewV1().String())
-	v1newer := dosa.UUID(uuid.NewV1().String())
+	v1uuid := dosa.UUID(uuid.Must(uuid.NewV1()).String())
+	v1newer := dosa.UUID(uuid.Must(uuid.NewV1()).String())
 	tests := []struct {
 		t1, t2 dosa.FieldValue
 		result int8
@@ -1569,7 +1569,7 @@ func createTestData(t *testing.T, sut *Connector, keyGenFunc func(int) string, i
 			"f1": dosa.FieldValue(keyGenFunc(x)),
 			"c1": dosa.FieldValue(int64(1)),
 			"c6": dosa.FieldValue(int32(x)),
-			"c7": dosa.FieldValue(dosa.UUID(uuid.NewV1().String()))})
+			"c7": dosa.FieldValue(dosa.UUID(uuid.Must(uuid.NewV1()).String()))})
 		assert.NoError(t, err)
 	}
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 9846493bc45dbefc53b7d0aee005163f0d34c2059b6511c92ff9bc7d66a2f0d1
-updated: 2018-05-15T14:37:43.630936-07:00
+hash: e1f56e45a7835c9819955e67720297f7f41b839a6a88c6eb7ee89fe191dc0cd3
+updated: 2018-08-29T08:13:43.844085095-07:00
 imports:
 - name: github.com/beorn7/perks
   version: 3a771d992973f24aa725d07868b467d1ddfceafb
@@ -22,6 +22,8 @@ imports:
   - syntax/lexer
   - util/runes
   - util/strings
+- name: github.com/gofrs/uuid
+  version: d41eeda0759468834c84365a32d1b1ec4264c75f
 - name: github.com/golang/mock
   version: c34cdb4725f4c3844d095133c6e40e448b86589b
   subpackages:
@@ -64,8 +66,6 @@ imports:
   - internal/util
   - nfs
   - xfs
-- name: github.com/satori/go.uuid
-  version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/uber-go/atomic
   version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
   subpackages:
@@ -75,15 +75,15 @@ imports:
   subpackages:
   - internal/mapstructure
 - name: github.com/uber-go/tally
-  version: 6f121596292a5ec8618b71ee3687fe42da73d289
+  version: ff17f3c43c065c3c2991f571e740eee43ea3a14a
 - name: github.com/uber/dosa-idl
-  version: 8a75cc9ec3d9cdf2542db437c784ae557b28ad17
+  version: ac79c598a228a5686923860f57cc5fd7044f225e
   subpackages:
   - .gen/dosa
   - .gen/dosa/dosaclient
   - .gen/dosa/dosatest
 - name: github.com/uber/tchannel-go
-  version: cc0c40929b0dbdb755b727a8c253de2b5d4af46b
+  version: 7f5c12c66261f3ac3c5dde959d65eed59e3b63af
   subpackages:
   - internal/argreader
   - relay
@@ -102,7 +102,7 @@ imports:
   - push
   - tallypush
 - name: go.uber.org/thriftrw
-  version: 43dfafd7bb1c99f0460d645a1959b73f6dfa536f
+  version: fb439a9a7f5a388d8606aae1c1ff6654b8b67fbe
   subpackages:
   - envelope
   - internal/envelope/exception
@@ -112,7 +112,7 @@ imports:
   - version
   - wire
 - name: go.uber.org/yarpc
-  version: f890b9f2fd812eb3f81efac46ccddf0e46d15210
+  version: 57163f1e97e7bf5573c50329be0fc302e7b145ca
   subpackages:
   - api/backoff
   - api/encoding
@@ -148,7 +148,7 @@ imports:
   - yarpcconfig
   - yarpcerrors
 - name: go.uber.org/zap
-  version: eeedf312bc6c57391d84767a4cd413f02a917974
+  version: ff33455a0e382e8a81d14dd7c922020b6b5e7982
   subpackages:
   - buffer
   - internal/bufferpool
@@ -156,7 +156,7 @@ imports:
   - internal/exit
   - zapcore
 - name: golang.org/x/net
-  version: 2491c5de3490fced2f6cff376127c667efeed857
+  version: 8a410e7b638dca158bf9e766925842f6651ff828
   repo: https://github.com/golang/net
   subpackages:
   - bpf
@@ -190,10 +190,12 @@ testImports:
   version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
+- name: github.com/satori/go.uuid
+  version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/sectioneight/md-to-godoc
   version: 79157ff08f1acd5c5b1d13d71c0adb7908dbb8a2
 - name: github.com/stretchr/testify
-  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
+  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
   - assert
 - name: github.com/yookoala/realpath

--- a/glide.yaml
+++ b/glide.yaml
@@ -15,8 +15,8 @@ import:
   version: ^1.4.0
 - package: github.com/pkg/errors
   version: ^0.8.0
-- package: github.com/satori/go.uuid
-  version: ^1.2.0
+- package: github.com/gofrs/uuid
+  version: ^3.1.0
 - package: github.com/uber/dosa-idl
   version: ^3
   subpackages:
@@ -35,8 +35,6 @@ testImport:
   version: ^1.2.1
   subpackages:
   - assert
-- package: github.com/uber/tchannel-go
-  version: ^1
 
 # The following packages are needed soley for build and test 
 # reporting related things. None of our actual code (including 

--- a/type.go
+++ b/type.go
@@ -22,7 +22,7 @@ package dosa
 
 import (
 	"github.com/pkg/errors"
-	"github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 )
 
 //go:generate stringer -type=Type
@@ -67,7 +67,7 @@ type UUID string
 // NewUUID is a helper for returning a new dosa.UUID value
 func NewUUID() UUID {
 	// return UUID(uuid.Must(uuid.NewV4()).String())
-	return UUID(uuid.NewV4().String())
+	return UUID(uuid.Must(uuid.NewV4()).String())
 }
 
 // Bytes gets the bytes from a UUID


### PR DESCRIPTION
The satori/go.uuid package has some serious known problems, particularly
with the generation of V4 UUIDs. It's also no longer maintained. The
recommended replacement is gofrs/uuid.

Additionally, the gofrs team accepted the change I made to the uuid
package about two years ago and released 3.1.0 which includes a feature
needed by the DOSA memory connector. This also removes that workaround.