### PR TITLE
test: replace missed satori/go.uuid (#361)

### DIFF
--- a/cmd/dosa/main.go
+++ b/cmd/dosa/main.go
@@ -23,10 +23,11 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/jessevdk/go-flags"
-	"github.com/uber-go/dosa"
 	"os"
 	"os/exec"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/uber-go/dosa"
 )
 
 // for testing, we make exit an overridable routine
@@ -40,11 +41,11 @@ type queryClientProvider func(opts GlobalOptions, scope, prefix, path, structNam
 
 // these are overridden at build-time w/ the -ldflags -X option
 var (
-	version   = "0.0.0"
-	githash   = "master"
-	timestamp = "now"
+	version           = "0.0.0"
+	githash           = "master"
+	timestamp         = "now"
 	javaclientVersion = "1.1.0-beta"
-	javaclient = os.Getenv("HOME") + "/.m2/target/dependency/java-client-" + javaclientVersion + ".jar"
+	javaclient        = os.Getenv("HOME") + "/.m2/target/dependency/java-client-" + javaclientVersion + ".jar"
 )
 
 // BuildInfo reports information about the binary build environment
@@ -131,8 +132,8 @@ dosa manages your schema both in production and development scopes`
 
 func downloadJar() {
 	fmt.Println("Downloading required dependencies... This may take some time...")
-    cmd := exec.Command( "mvn", "org.apache.maven.plugins:maven-dependency-plugin:RELEASE:copy",
-    	"-Dartifact=com.uber.dosa:java-client:" + javaclientVersion, "-Dproject.basedir=" + os.Getenv("HOME") + "/.m2/")
+	cmd := exec.Command("mvn", "org.apache.maven.plugins:maven-dependency-plugin:RELEASE:copy",
+		"-Dartifact=com.uber.dosa:java-client:"+javaclientVersion, "-Dproject.basedir="+os.Getenv("HOME")+"/.m2/")
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out

--- a/cmd/dosa/query.go
+++ b/cmd/dosa/query.go
@@ -57,7 +57,7 @@ type QueryCmd struct {
 	Prefix        string    `short:"p" long:"prefix" description:"Name prefix for schema types." hidden:"true"`
 	Path          string    `long:"path" description:"Path to source." required:"true"`
 	JarPath       string    `short:"j" long:"jarpath" description:"Path of the jar. This jar contains schema entities."`
-	ClassNames  []string    `short:"c" long:"classnames" description:"Classes contain schema."`
+	ClassNames    []string  `short:"c" long:"classnames" description:"Classes contain schema."`
 	provideClient queryClientProvider
 }
 

--- a/cmd/dosa/schema.go
+++ b/cmd/dosa/schema.go
@@ -78,7 +78,7 @@ type SchemaCmd struct {
 	NamePrefix    string    `short:"n" long:"namePrefix" description:"Name prefix for schema types."`
 	Prefix        string    `short:"p" long:"prefix" description:"Name prefix for schema types." hidden:"true"`
 	JarPath       string    `short:"j" long:"jarpath" description:"Path of the jar. This jar contains schema entities."`
-	ClassNames  []string    `short:"c" long:"classnames" description:"Classes contain schema."`
+	ClassNames    []string  `short:"c" long:"classnames" description:"Classes contain schema."`
 	provideClient adminClientProvider
 }
 
@@ -301,8 +301,8 @@ func (c *SchemaStatus) Execute(args []string) error {
 // SchemaDump contains data for executing the schema dump command
 type SchemaDump struct {
 	*SchemaOptions
-	Format       string `long:"format" short:"f" description:"output format" choice:"cql" choice:"uql" choice:"avro" default:"cql"`
-	JarPath      string `short:"j" long:"jarpath" description:"Path of the jar. This jar contains schema entities."`
+	Format     string   `long:"format" short:"f" description:"output format" choice:"cql" choice:"uql" choice:"avro" default:"cql"`
+	JarPath    string   `short:"j" long:"jarpath" description:"Path of the jar. This jar contains schema entities."`
 	ClassNames []string `short:"c" long:"classnames" description:"Classes contain schema."`
 	Args       struct {
 		Paths []string `positional-arg-name:"paths"`
@@ -388,7 +388,7 @@ func (c *SchemaDump) doSchemaDumpInJavaClient() {
 			args = append(args, element)
 		}
 	}
-	
+
 	if c.Verbose {
 		args = append(args, "-v")
 	}

--- a/connectors/memory/memory.go
+++ b/connectors/memory/memory.go
@@ -28,8 +28,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 	"github.com/uber-go/dosa"
 	"github.com/uber-go/dosa/connectors/base"
 	"github.com/uber-go/dosa/encoding"

--- a/connectors/routing/connector_test.go
+++ b/connectors/routing/connector_test.go
@@ -26,7 +26,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/dosa"
 	"github.com/uber-go/dosa/connectors/devnull"
@@ -1025,7 +1025,7 @@ func createTestData(t *testing.T, rc *Connector, keyGenFunc func(int) string, id
 			"f1": dosa.FieldValue(keyGenFunc(x)),
 			"c1": dosa.FieldValue(int64(1)),
 			"c6": dosa.FieldValue(int32(x)),
-			"c7": dosa.FieldValue(dosa.UUID(uuid.NewV1().String()))})
+			"c7": dosa.FieldValue(dosa.UUID(uuid.Must(uuid.NewV1()).String()))})
 		assert.NoError(t, err)
 	}
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 8b80aa59f75a2ce7eeaf511ffe1fbf97b951e30f3819301d0da63080b8962bc8
-updated: 2018-08-03T16:03:03.359809516-07:00
+hash: e1f56e45a7835c9819955e67720297f7f41b839a6a88c6eb7ee89fe191dc0cd3
+updated: 2018-10-16T14:42:38.207209479-07:00
 imports:
 - name: github.com/beorn7/perks
   version: 3a771d992973f24aa725d07868b467d1ddfceafb
@@ -23,7 +23,7 @@ imports:
   - util/runes
   - util/strings
 - name: github.com/gofrs/uuid
-  version: d41eeda0759468834c84365a32d1b1ec4264c75f
+  version: 370558f003bfe29580cd0f698d8640daccdcc45c
 - name: github.com/golang/mock
   version: c34cdb4725f4c3844d095133c6e40e448b86589b
   subpackages:
@@ -102,7 +102,7 @@ imports:
   - push
   - tallypush
 - name: go.uber.org/thriftrw
-  version: fb439a9a7f5a388d8606aae1c1ff6654b8b67fbe
+  version: 7c449ccc4449ee826f5063a81e7f48b178396ef1
   subpackages:
   - envelope
   - internal/envelope/exception
@@ -112,7 +112,7 @@ imports:
   - version
   - wire
 - name: go.uber.org/yarpc
-  version: fc2d75d3b5e30fc81e5dc2375667bbd6333b0099
+  version: e9ce3a1b4a82c45d493d700bdbaa3d40c62348d9
   subpackages:
   - api/backoff
   - api/encoding
@@ -148,7 +148,7 @@ imports:
   - yarpcconfig
   - yarpcerrors
 - name: go.uber.org/zap
-  version: 4d45f9617f7d90f7a663ff21c7a4321dbe78098b
+  version: ff33455a0e382e8a81d14dd7c922020b6b5e7982
   subpackages:
   - buffer
   - internal/bufferpool
@@ -156,7 +156,7 @@ imports:
   - internal/exit
   - zapcore
 - name: golang.org/x/net
-  version: f4c29de78a2a91c00474a2e689954305c350adf9
+  version: 640f4622ab692b87c2f3a94265e6f579fe38263d
   repo: https://github.com/golang/net
   subpackages:
   - bpf
@@ -190,8 +190,6 @@ testImports:
   version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
-- name: github.com/satori/go.uuid
-  version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/sectioneight/md-to-godoc
   version: 79157ff08f1acd5c5b1d13d71c0adb7908dbb8a2
 - name: github.com/stretchr/testify

--- a/type.go
+++ b/type.go
@@ -21,8 +21,8 @@
 package dosa
 
 import (
-	"github.com/pkg/errors"
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 )
 
 //go:generate stringer -type=Type


### PR DESCRIPTION
961abe5 swapped out `satori/go.uuid` with `gofrs/uuid` but missed this one spot in a routing connector test.

This pull request is broken into three parts. The first is formatting issues (`go fmt` from v1.10). The second is the fix for a missed `satori/go.uuid` replacement. The last is updating dependencies, which drops `satori/go.uuid` from glide.lock, but because of glide I'm also including updates of other dependent libraries. Details are in each commit message.