### PR TITLE
Add a 'columns' tag for Index definitions that defines which fields should be denormalized into the index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## v3.4.3 (unreleased)
- - Nothing yet
+ - Add optional 'columns' tag to Index definitions
 
 ## v3.4.2 (2019-03-26)
  - Update version.VERSION

--- a/entity.go
+++ b/entity.go
@@ -166,13 +166,19 @@ func (cd *ColumnDefinition) Clone() *ColumnDefinition {
 
 // IndexDefinition stores information about a DOSA entity's index
 type IndexDefinition struct {
-	Key *PrimaryKey
+	Key     *PrimaryKey
+	Columns []string
 }
 
 // Clone returns a deep copy of IndexDefinition
 func (id *IndexDefinition) Clone() *IndexDefinition {
+	columns := make([]string, len(id.Columns))
+	for i, c := range id.Columns {
+		columns[i] = c
+	}
 	return &IndexDefinition{
-		Key: id.Key.Clone(),
+		Key:     id.Key.Clone(),
+		Columns: columns,
 	}
 }
 

--- a/entity.go
+++ b/entity.go
@@ -173,9 +173,7 @@ type IndexDefinition struct {
 // Clone returns a deep copy of IndexDefinition
 func (id *IndexDefinition) Clone() *IndexDefinition {
 	columns := make([]string, len(id.Columns))
-	for i, c := range id.Columns {
-		columns[i] = c
-	}
+	copy(columns, id.Columns)
 	return &IndexDefinition{
 		Key:     id.Key.Clone(),
 		Columns: columns,

--- a/entity_parser.go
+++ b/entity_parser.go
@@ -49,7 +49,7 @@ var (
 
 	namePattern0 = regexp.MustCompile(`name\s*=\s*(\S*)`)
 
-	columnsPattern0 = regexp.MustCompile(`columns\s*=\s*\(([^\(\)]+)\)`)
+	columnsPattern = regexp.MustCompile(`columns\s*=\s*\(([^\(\)]+)\)`)
 
 	etlPattern0 = regexp.MustCompile(`etl\s*=\s*(\S*)`)
 
@@ -348,13 +348,13 @@ func parseNameTag(tag, defaultName string) (string, string, error) {
 	return fullNameTag, name, nil
 }
 
-// parseColumnsTag functions parse DOSA "columns" tag
+// parseColumnsTag parses "columns" tag of dosa.Index in the entity
+// returns full string of columns and a slice of column fields.
 func parseColumnsTag(tag string) (string, []string, error) {
 	fullColumnsTag := ""
-	// var indexColumns []string
-	indexColumns := []string{}
+	var indexColumns []string
 	var fields []string
-	matches := columnsPattern0.FindStringSubmatch(tag)
+	matches := columnsPattern.FindStringSubmatch(tag)
 	if len(matches) == 2 {
 		fullColumnsTag = matches[0]
 		fields = strings.Split(matches[1], ",")

--- a/entity_parser.go
+++ b/entity_parser.go
@@ -348,8 +348,8 @@ func parseNameTag(tag, defaultName string) (string, string, error) {
 	return fullNameTag, name, nil
 }
 
-// parseColumnsTag parses "columns" tag of dosa.Index in the entity
-// returns full string of columns and a slice of column fields.
+// parseColumnsTag parses the "columns" tag of a dosa.Index in the entity. It returns
+// the matched section of the tag string and a list of the selected fields.
 func parseColumnsTag(tag string) (string, []string, error) {
 	fullColumnsTag := ""
 	var indexColumns []string

--- a/entity_parser_index_test.go
+++ b/entity_parser_index_test.go
@@ -39,7 +39,8 @@ func TestSingleIndexNoParen(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, map[string]*IndexDefinition{
 		"searchbydata": {
-			Key: &PrimaryKey{PartitionKeys: []string{"data"}},
+			Key:     &PrimaryKey{PartitionKeys: []string{"data"}},
+			Columns: []string{},
 		},
 	}, dosaTable.Indexes)
 }
@@ -71,10 +72,12 @@ func TestMultipleIndexes(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, map[string]*IndexDefinition{
 		"searchbydata": {
-			Key: &PrimaryKey{PartitionKeys: []string{"data"}},
+			Key:     &PrimaryKey{PartitionKeys: []string{"data"}},
+			Columns: []string{},
 		},
 		"searchbydate": {
-			Key: &PrimaryKey{PartitionKeys: []string{"date"}},
+			Key:     &PrimaryKey{PartitionKeys: []string{"date"}},
+			Columns: []string{},
 		},
 	}, dosaTable.Indexes)
 }
@@ -106,6 +109,7 @@ func TestComplexIndexes(t *testing.T) {
 					},
 				},
 			},
+			Columns: []string{},
 		},
 		"index_date": {
 			Key: &PrimaryKey{
@@ -117,6 +121,42 @@ func TestComplexIndexes(t *testing.T) {
 					},
 				},
 			},
+			Columns: []string{},
+		},
+	}, dosaTable.Indexes)
+}
+
+type IndexesWithColumnsTag struct {
+	Entity       `dosa:"primaryKey=(ID)"`
+	SearchByCity Index `dosa:"key=(City, Payload) columns=(ID)"`
+	SearchByID   Index `dosa:"key=(City) columns=(ID, Payload)"`
+
+	ID      UUID
+	City    string
+	Payload []byte
+}
+
+func TestIndexesWithColumnsTag(t *testing.T) {
+	dosaTable, err := TableFromInstance(&IndexesWithColumnsTag{})
+	assert.Nil(t, err)
+	assert.Equal(t, map[string]*IndexDefinition{
+		"searchbycity": {
+			Key: &PrimaryKey{
+				PartitionKeys: []string{"city"},
+				ClusteringKeys: []*ClusteringKey{
+					{
+						Name:       "payload",
+						Descending: false,
+					},
+				},
+			},
+			Columns: []string{"id"},
+		},
+		"searchbyid": {
+			Key: &PrimaryKey{
+				PartitionKeys: []string{"city"},
+			},
+			Columns: []string{"id", "payload"},
 		},
 	}, dosaTable.Indexes)
 }

--- a/entity_parser_index_test.go
+++ b/entity_parser_index_test.go
@@ -39,8 +39,7 @@ func TestSingleIndexNoParen(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, map[string]*IndexDefinition{
 		"searchbydata": {
-			Key:     &PrimaryKey{PartitionKeys: []string{"data"}},
-			Columns: []string{},
+			Key: &PrimaryKey{PartitionKeys: []string{"data"}},
 		},
 	}, dosaTable.Indexes)
 }
@@ -72,12 +71,10 @@ func TestMultipleIndexes(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, map[string]*IndexDefinition{
 		"searchbydata": {
-			Key:     &PrimaryKey{PartitionKeys: []string{"data"}},
-			Columns: []string{},
+			Key: &PrimaryKey{PartitionKeys: []string{"data"}},
 		},
 		"searchbydate": {
-			Key:     &PrimaryKey{PartitionKeys: []string{"date"}},
-			Columns: []string{},
+			Key: &PrimaryKey{PartitionKeys: []string{"date"}},
 		},
 	}, dosaTable.Indexes)
 }
@@ -109,7 +106,6 @@ func TestComplexIndexes(t *testing.T) {
 					},
 				},
 			},
-			Columns: []string{},
 		},
 		"index_date": {
 			Key: &PrimaryKey{
@@ -121,7 +117,6 @@ func TestComplexIndexes(t *testing.T) {
 					},
 				},
 			},
-			Columns: []string{},
 		},
 	}, dosaTable.Indexes)
 }

--- a/entity_parser_key_parser_test.go
+++ b/entity_parser_key_parser_test.go
@@ -750,7 +750,6 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "SearchByKey",
-			Columns:        []string{},
 			Error:          nil,
 		},
 		{
@@ -761,7 +760,6 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "SearchByKey",
-			Columns:        []string{},
 			Error:          nil,
 		},
 		{
@@ -772,7 +770,6 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "SearchByKey",
-			Columns:        []string{},
 			Error:          nil,
 		},
 		{
@@ -783,7 +780,6 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "SearchByKey",
-			Columns:        []string{},
 			Error:          nil,
 		},
 		{
@@ -794,7 +790,6 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "SearchByKey",
-			Columns:        []string{},
 			Error:          nil,
 		},
 		{
@@ -805,7 +800,6 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "SearchByKey",
-			Columns:        []string{},
 			Error:          nil,
 		},
 		{
@@ -816,7 +810,6 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "SearchByKey",
-			Columns:        []string{},
 			Error:          nil,
 		},
 		{
@@ -827,7 +820,6 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "SearchByKey",
-			Columns:        []string{},
 			Error:          nil,
 		},
 		{
@@ -851,7 +843,6 @@ func TestIndexParse(t *testing.T) {
 				},
 			},
 			InputIndexName: "SearchByKey",
-			Columns:        []string{},
 			Error:          nil,
 		},
 		{
@@ -875,7 +866,6 @@ func TestIndexParse(t *testing.T) {
 				},
 			},
 			InputIndexName: "SearchByKey",
-			Columns:        []string{},
 			Error:          nil,
 		},
 		{
@@ -883,7 +873,6 @@ func TestIndexParse(t *testing.T) {
 			ExpectedIndexName: "jj",
 			PrimaryKey:        nil,
 			InputIndexName:    "SearchByKey",
-			Columns:           []string{},
 			Error:             errors.New("ok,adsf"),
 		},
 		{
@@ -891,7 +880,6 @@ func TestIndexParse(t *testing.T) {
 			ExpectedIndexName: "jj",
 			PrimaryKey:        nil,
 			InputIndexName:    "SearchByKey",
-			Columns:           []string{},
 			Error:             errors.New("dosa.Index SearchByKey with an invalid dosa index tag"),
 		},
 		{
@@ -899,7 +887,6 @@ func TestIndexParse(t *testing.T) {
 			ExpectedIndexName: "jj",
 			PrimaryKey:        nil,
 			InputIndexName:    "SearchByKey",
-			Columns:           []string{},
 			Error:             errors.New("invalid name tag:  name=jj**"),
 		},
 		{
@@ -907,7 +894,6 @@ func TestIndexParse(t *testing.T) {
 			ExpectedIndexName: "jj",
 			PrimaryKey:        nil,
 			InputIndexName:    "SearchByKey",
-			Columns:           []string{},
 			Error:             errors.New("index field SearchByKey with an invalid dosa index tag: nxxx"),
 		},
 		{
@@ -918,7 +904,6 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "SearchByKey",
-			Columns:        []string{},
 			Error:          nil,
 		},
 		{
@@ -929,7 +914,6 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "",
-			Columns:        []string{},
 			Error:          errors.New("invalid name tag"),
 		},
 		{
@@ -940,7 +924,6 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "searchByKey",
-			Columns:        []string{},
 			Error:          errors.New("index name (searchByKey) must be exported, try (SearchByKey) instead"),
 		},
 		{

--- a/entity_parser_key_parser_test.go
+++ b/entity_parser_key_parser_test.go
@@ -739,6 +739,7 @@ func TestIndexParse(t *testing.T) {
 		InputIndexName    string
 		ExpectedIndexName string
 		PrimaryKey        *PrimaryKey
+		Columns           []string
 		Error             error
 	}{
 		{
@@ -749,6 +750,7 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "SearchByKey",
+			Columns:        []string{},
 			Error:          nil,
 		},
 		{
@@ -759,6 +761,7 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "SearchByKey",
+			Columns:        []string{},
 			Error:          nil,
 		},
 		{
@@ -769,6 +772,7 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "SearchByKey",
+			Columns:        []string{},
 			Error:          nil,
 		},
 		{
@@ -779,6 +783,7 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "SearchByKey",
+			Columns:        []string{},
 			Error:          nil,
 		},
 		{
@@ -789,6 +794,7 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "SearchByKey",
+			Columns:        []string{},
 			Error:          nil,
 		},
 		{
@@ -799,6 +805,7 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "SearchByKey",
+			Columns:        []string{},
 			Error:          nil,
 		},
 		{
@@ -809,6 +816,7 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "SearchByKey",
+			Columns:        []string{},
 			Error:          nil,
 		},
 		{
@@ -819,6 +827,7 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "SearchByKey",
+			Columns:        []string{},
 			Error:          nil,
 		},
 		{
@@ -842,6 +851,7 @@ func TestIndexParse(t *testing.T) {
 				},
 			},
 			InputIndexName: "SearchByKey",
+			Columns:        []string{},
 			Error:          nil,
 		},
 		{
@@ -865,6 +875,7 @@ func TestIndexParse(t *testing.T) {
 				},
 			},
 			InputIndexName: "SearchByKey",
+			Columns:        []string{},
 			Error:          nil,
 		},
 		{
@@ -872,6 +883,7 @@ func TestIndexParse(t *testing.T) {
 			ExpectedIndexName: "jj",
 			PrimaryKey:        nil,
 			InputIndexName:    "SearchByKey",
+			Columns:           []string{},
 			Error:             errors.New("ok,adsf"),
 		},
 		{
@@ -879,6 +891,7 @@ func TestIndexParse(t *testing.T) {
 			ExpectedIndexName: "jj",
 			PrimaryKey:        nil,
 			InputIndexName:    "SearchByKey",
+			Columns:           []string{},
 			Error:             errors.New("dosa.Index SearchByKey with an invalid dosa index tag"),
 		},
 		{
@@ -886,6 +899,7 @@ func TestIndexParse(t *testing.T) {
 			ExpectedIndexName: "jj",
 			PrimaryKey:        nil,
 			InputIndexName:    "SearchByKey",
+			Columns:           []string{},
 			Error:             errors.New("invalid name tag:  name=jj**"),
 		},
 		{
@@ -893,6 +907,7 @@ func TestIndexParse(t *testing.T) {
 			ExpectedIndexName: "jj",
 			PrimaryKey:        nil,
 			InputIndexName:    "SearchByKey",
+			Columns:           []string{},
 			Error:             errors.New("index field SearchByKey with an invalid dosa index tag: nxxx"),
 		},
 		{
@@ -903,6 +918,7 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "SearchByKey",
+			Columns:        []string{},
 			Error:          nil,
 		},
 		{
@@ -913,6 +929,7 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "",
+			Columns:        []string{},
 			Error:          errors.New("invalid name tag"),
 		},
 		{
@@ -923,18 +940,53 @@ func TestIndexParse(t *testing.T) {
 				ClusteringKeys: nil,
 			},
 			InputIndexName: "searchByKey",
+			Columns:        []string{},
 			Error:          errors.New("index name (searchByKey) must be exported, try (SearchByKey) instead"),
+		},
+		{
+			Tag:               "name=jj key=ok columns=(ok)",
+			ExpectedIndexName: "jj",
+			PrimaryKey: &PrimaryKey{
+				PartitionKeys:  []string{"ok"},
+				ClusteringKeys: nil,
+			},
+			InputIndexName: "SearchByKey",
+			Columns:        []string{"ok"},
+			Error:          nil,
+		},
+		{
+			Tag:               "name=jj key=ok columns=(ok, test, hi,)",
+			ExpectedIndexName: "jj",
+			PrimaryKey: &PrimaryKey{
+				PartitionKeys:  []string{"ok"},
+				ClusteringKeys: nil,
+			},
+			InputIndexName: "SearchByKey",
+			Columns:        []string{"ok", "test", "hi"},
+			Error:          nil,
+		},
+		{
+			Tag:               "name=jj key=ok columns=(ok, test, (hi),)",
+			ExpectedIndexName: "jj",
+			PrimaryKey: &PrimaryKey{
+				PartitionKeys:  []string{"ok"},
+				ClusteringKeys: nil,
+			},
+			InputIndexName: "SearchByKey",
+			Columns:        []string{"ok", "test", "hi"},
+			Error:          errors.New("index field SearchByKey with an invalid dosa index tag: columns=(ok, test, (hi),)"),
 		},
 	}
 
 	for _, d := range data {
-		name, primaryKey, err := parseIndexTag(d.InputIndexName, d.Tag)
+		name, primaryKey, columns, err := parseIndexTag(d.InputIndexName, d.Tag)
 		if d.Error != nil {
 			assert.Contains(t, err.Error(), d.Error.Error())
 		} else {
 			assert.Nil(t, err)
 			assert.Equal(t, name, d.ExpectedIndexName)
 			assert.Equal(t, primaryKey, d.PrimaryKey)
+			assert.Equal(t, columns, d.Columns)
 		}
 	}
 }

--- a/entity_test.go
+++ b/entity_test.go
@@ -342,12 +342,14 @@ func getValidEntityDefinition() *dosa.EntityDefinition {
 						},
 					},
 				},
+				Columns: []string{},
 			},
 
 			"index2": {
 				Key: &dosa.PrimaryKey{
 					PartitionKeys: []string{"bar"},
 				},
+				Columns: []string{},
 			},
 		},
 		Columns: []*dosa.ColumnDefinition{

--- a/finder.go
+++ b/finder.go
@@ -263,14 +263,14 @@ func tableFromStructType(structName string, structType *ast.StructType, packageP
 			for _, fieldName := range field.Names {
 				name := fieldName.Name
 				if kind == packagePrefix+"."+indexName || (packagePrefix == "" && kind == indexName) {
-					indexName, indexKey, err := parseIndexTag(name, dosaTag)
+					indexName, indexKey, indexColumns, err := parseIndexTag(name, dosaTag)
 					if err != nil {
 						return nil, err
 					}
 					if _, exist := t.Indexes[indexName]; exist {
 						return nil, errors.Errorf("index name is duplicated: %s", indexName)
 					}
-					t.Indexes[indexName] = &IndexDefinition{Key: indexKey}
+					t.Indexes[indexName] = &IndexDefinition{Key: indexKey, Columns: indexColumns}
 				} else {
 					firstRune, _ := utf8.DecodeRuneInString(name)
 					if unicode.IsLower(firstRune) {
@@ -293,14 +293,14 @@ func tableFromStructType(structName string, structType *ast.StructType, packageP
 
 			if len(field.Names) == 0 {
 				if kind == packagePrefix+"."+indexName || (packagePrefix == "" && kind == indexName) {
-					indexName, indexKey, err := parseIndexTag("", dosaTag)
+					indexName, indexKey, indexColumns, err := parseIndexTag("", dosaTag)
 					if err != nil {
 						return nil, err
 					}
 					if _, exist := t.Indexes[indexName]; exist {
 						return nil, errors.Errorf("index name is duplicated: %s", indexName)
 					}
-					t.Indexes[indexName] = &IndexDefinition{Key: indexKey}
+					t.Indexes[indexName] = &IndexDefinition{Key: indexKey, Columns: indexColumns}
 				}
 			}
 		}

--- a/finder_test.go
+++ b/finder_test.go
@@ -76,6 +76,7 @@ func TestParser(t *testing.T) {
 		"multipleindexes":               &MultipleIndexes{},
 		"complexindexes":                &ComplexIndexes{},
 		"scopemetadata":                 &ScopeMetadata{},
+		"indexeswithcolumnstag":         &IndexesWithColumnsTag{},
 	}
 	entitiesExcludedForTest := map[string]interface{}{
 		"clienttestentity1":      struct{}{}, // skip, see https://jira.uberinternal.com/browse/DOSA-788


### PR DESCRIPTION
The index table is built on selecting all the fields in the entity. It’s costly to read/write with large payload. Using columns tag to make it flexible,  which could reduce the payload when build the materialized view.

This pull is to extend the annotation. Users could choose to use **columns=(field1, field2, field3)** to limit the columns required to build the index table.