### PR TITLE
cover corner cases checking columns tag valid usage

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -328,6 +328,17 @@ func (e *EntityDefinition) EnsureValid() error {
 			}
 			keyNamesSeen[c.Name] = struct{}{}
 		}
+
+		columnsTagFieldsSeen := map[string]struct{}{}
+		for _, c := range index.Columns {
+			if _, ok := columnNamesSeen[c]; !ok {
+				return errors.Errorf("columns tag field does not refer to a column: %q", c)
+			}
+			if _, ok := columnsTagFieldsSeen[c]; ok {
+				return errors.Errorf("a column cannot be used twice in column tags: %q", c)
+			}
+			columnsTagFieldsSeen[c] = struct{}{}
+		}
 	}
 
 	return nil

--- a/entity_test.go
+++ b/entity_test.go
@@ -219,6 +219,12 @@ func TestEntityDefinitionEnsureValidForIndex(t *testing.T) {
 	noClusteringKey := getValidEntityDefinition()
 	noClusteringKey.Indexes["index1"].Key.ClusteringKeys = []*dosa.ClusteringKey{}
 
+	invalidColumnsTagField := getValidEntityDefinition()
+	invalidColumnsTagField.Indexes["index1"].Columns = []string{"badfoo"}
+
+	dupColumnsTagField := getValidEntityDefinition()
+	dupColumnsTagField.Indexes["index1"].Columns = []string{"foo", "foo"}
+
 	data := []testData{
 		{
 			e:     invalidName,
@@ -284,6 +290,16 @@ func TestEntityDefinitionEnsureValidForIndex(t *testing.T) {
 			e:     nilClusteringKey,
 			valid: false,
 			msg:   "nil clustering key",
+		},
+		{
+			e:     invalidColumnsTagField,
+			valid: false,
+			msg:   "columns tag field does not refer to a column: \"badfoo\"",
+		},
+		{
+			e:     dupColumnsTagField,
+			valid: false,
+			msg:   "a column cannot be used twice in column tags: \"foo\"",
 		},
 	}
 


### PR DESCRIPTION
1. fields in columns tag must refer to a column.
2. a column cannot be used twice.