### PR TITLE
Rename CLI command "schema check" to "schema upsertable"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  - Add optional 'columns' tag to Index definitions
  - update dosa-idl into v3.2.1
  - add columns support to materialized view creation using Schema dump
+ - rename CLI command "schema check" to "schema upsertable"
 
 ## v3.4.2 (2019-03-26)
  - Update version.VERSION

--- a/cmd/dosa/main.go
+++ b/cmd/dosa/main.go
@@ -101,7 +101,7 @@ dosa manages your schema both in production and development scopes`
 	_, _ = c.AddCommand("show", "Show scope MD", "show scope metadata", newScopeShow(provideMDClient))
 
 	c, _ = OptionsParser.AddCommand("schema", "commands to manage schemas", "check or update schemas", &SchemaOptions{})
-	_, _ = c.AddCommand("check", "Check schema", "check the schema", newSchemaCheck(provideAdminClient))
+	_, _ = c.AddCommand("upsertable", "Check upsertability of schema", "schema upsertability", newSchemaUpsertable(provideAdminClient))
 	_, _ = c.AddCommand("upsert", "Upsert schema", "insert or update the schema", newSchemaUpsert(provideAdminClient))
 	_, _ = c.AddCommand("dump", "Dump schema", "display the schema in a given format", &SchemaDump{})
 	_, _ = c.AddCommand("status", "Check schema status", "Check application status of schema", newSchemaStatus(provideAdminClient))

--- a/cmd/dosa/main_test.go
+++ b/cmd/dosa/main_test.go
@@ -42,7 +42,7 @@ func TestMissingSubcommands(t *testing.T) {
 	exit = func(r int) {}
 	os.Args = []string{"dosa", "schema"}
 	main()
-	assert.Contains(t, c.stop(true), "check, dump, status or upsert")
+	assert.Contains(t, c.stop(true), "dump, status, upsert or upsertable")
 }
 
 func TestHostOptionButNothingElse(t *testing.T) {
@@ -57,7 +57,7 @@ func TestHostOptionButNothingElse(t *testing.T) {
 func TestInvalidHostOld(t *testing.T) {
 	c := StartCapture()
 	exit = func(r int) {}
-	os.Args = []string{"dosa", "--host", "invalid-hostname.", "schema", "check", "--scope", "bar", "--prefix", "foo", "../../testentity"}
+	os.Args = []string{"dosa", "--host", "invalid-hostname.", "schema", "upsertable", "--scope", "bar", "--prefix", "foo", "../../testentity"}
 	main()
 	output := c.stop(true)
 	assert.Contains(t, output, "invalid-hostname")
@@ -68,7 +68,7 @@ func TestInvalidHostOld(t *testing.T) {
 func TestInvalidHost(t *testing.T) {
 	c := StartCapture()
 	exit = func(r int) {}
-	os.Args = []string{"dosa", "--host", "invalid-hostname.", "schema", "check", "--scope", "bar", "--namePrefix", "foo", "../../testentity"}
+	os.Args = []string{"dosa", "--host", "invalid-hostname.", "schema", "upsertable", "--scope", "bar", "--namePrefix", "foo", "../../testentity"}
 	main()
 	output := c.stop(true)
 	assert.Contains(t, output, "invalid-hostname")
@@ -80,7 +80,7 @@ func TestInvalidHost(t *testing.T) {
 func TestInvalidPort(t *testing.T) {
 	c := StartCapture()
 	exit = func(r int) {}
-	os.Args = []string{"dosa", "-p", "invalid-port", "schema", "check", "--scope", "bar", "--namePrefix", "foo", "../../testentity"}
+	os.Args = []string{"dosa", "-p", "invalid-port", "schema", "upsertable", "--scope", "bar", "--namePrefix", "foo", "../../testentity"}
 	main()
 	output := c.stop(true)
 	assert.Contains(t, output, "invalid-port")

--- a/cmd/dosa/schema.go
+++ b/cmd/dosa/schema.go
@@ -47,7 +47,7 @@ var (
 
 type scopeFlag string
 
-const schemaCheck = "schema check"
+const schemaUpsertable = "schema upsertable"
 const schemaUpsert = "schema upsert"
 const java = "java"
 
@@ -155,7 +155,7 @@ func (c *SchemaCmd) doSchemaOp(name string, f func(dosa.AdminClient, context.Con
 
 func (c *SchemaCmd) doSchemaOpInJavaClient(op string) {
 	var schemaOp string
-	if strings.Compare(op, schemaCheck) == 0 {
+	if strings.Compare(op, schemaUpsertable) == 0 {
 		schemaOp = "CAN_UPSERT"
 	} else if strings.Compare(op, schemaUpsert) == 0 {
 		schemaOp = "UPSERT"
@@ -199,25 +199,25 @@ func (c *SchemaCmd) doSchemaOpInJavaClient(op string) {
 	fmt.Printf("%s", out.String())
 }
 
-// SchemaCheck holds the options for 'schema check'
-type SchemaCheck struct {
+// SchemaUpsertable holds the options for 'schema upsertable'
+type SchemaUpsertable struct {
 	*SchemaCmd
 	Args struct {
 		Paths []string `positional-arg-name:"paths"`
 	} `positional-args:"yes"`
 }
 
-func newSchemaCheck(provideClient adminClientProvider) *SchemaCheck {
-	return &SchemaCheck{
+func newSchemaUpsertable(provideClient adminClientProvider) *SchemaUpsertable {
+	return &SchemaUpsertable{
 		SchemaCmd: &SchemaCmd{
 			provideClient: provideClient,
 		},
 	}
 }
 
-// Execute executes a schema check command
-func (c *SchemaCheck) Execute(args []string) error {
-	return c.doSchemaOp(schemaCheck, dosa.AdminClient.CanUpsertSchema, c.Args.Paths)
+// Execute executes a schema upsertable command
+func (c *SchemaUpsertable) Execute(args []string) error {
+	return c.doSchemaOp(schemaUpsertable, dosa.AdminClient.CanUpsertSchema, c.Args.Paths)
 }
 
 // SchemaUpsert contains data for executing schema upsert command.

--- a/cmd/dosa/schema_test.go
+++ b/cmd/dosa/schema_test.go
@@ -125,7 +125,7 @@ func TestSchema_DefaultsOldname(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		for _, cmd := range []string{"check", "upsert", "status"} {
+		for _, cmd := range []string{"upsertable", "upsert", "status"} {
 			os.Args = []string{
 				"dosa",
 				"--service", tc.serviceName,
@@ -157,7 +157,7 @@ func TestSchema_DefaultsNewname(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		for _, cmd := range []string{"check", "upsert", "status"} {
+		for _, cmd := range []string{"upsertable", "upsert", "status"} {
 			os.Args = []string{
 				"dosa",
 				"--service", tc.serviceName,
@@ -174,7 +174,7 @@ func TestSchema_DefaultsNewname(t *testing.T) {
 }
 
 func TestSchema_ScopeRequired(t *testing.T) {
-	for _, cmd := range []string{"check", "upsert"} {
+	for _, cmd := range []string{"upsertable", "upsert"} {
 		c := StartCapture()
 		exit = func(r int) {}
 		os.Args = []string{
@@ -190,7 +190,7 @@ func TestSchema_ScopeRequired(t *testing.T) {
 }
 
 func TestSchema_PrefixRequired(t *testing.T) {
-	for _, cmd := range []string{"check", "upsert"} {
+	for _, cmd := range []string{"upsertable", "upsert"} {
 		c := StartCapture()
 		exit = func(r int) {}
 		os.Args = []string{
@@ -208,9 +208,9 @@ func TestSchema_PrefixRequired(t *testing.T) {
 func TestSchema_InvalidDirectory(t *testing.T) {
 	// dump is a special snowflake
 	prefixMap := map[string]bool{
-		"check":  true,
-		"upsert": true,
-		"dump":   false,
+		"upsertable": true,
+		"upsert":     true,
+		"dump":       false,
 	}
 	for cmd, hasPrefix := range prefixMap {
 		c := StartCapture()
@@ -236,9 +236,9 @@ func TestSchema_InvalidDirectory(t *testing.T) {
 func TestSchema_NoEntitiesFound(t *testing.T) {
 	// dump is a special snowflake
 	prefixMap := map[string]bool{
-		"check":  true,
-		"upsert": true,
-		"dump":   false,
+		"upsertable": true,
+		"upsert":     true,
+		"dump":       false,
 	}
 	for cmd, hasPrefix := range prefixMap {
 		c := StartCapture()
@@ -290,7 +290,7 @@ func TestSchema_Check_Happy(t *testing.T) {
 		return dosa.NewAdminClient(mc), nil
 	}
 
-	schemaCheck := SchemaCheck{
+	schemaUpsertable := SchemaUpsertable{
 		SchemaCmd: &SchemaCmd{
 			SchemaOptions: &SchemaOptions{
 				Excludes: []string{"_test.go", "excludeme.go"},
@@ -301,9 +301,9 @@ func TestSchema_Check_Happy(t *testing.T) {
 			provideClient: provideClient,
 		},
 	}
-	schemaCheck.Args.Paths = []string{"../../testentity"}
+	schemaUpsertable.Args.Paths = []string{"../../testentity"}
 
-	err := schemaCheck.Execute(nil)
+	err := schemaUpsertable.Execute(nil)
 	assert.NoError(t, err)
 }
 
@@ -330,7 +330,7 @@ func TestSchema_Check_Happy_New(t *testing.T) {
 		return dosa.NewAdminClient(mc), nil
 	}
 
-	schemaCheck := SchemaCheck{
+	schemaUpsertable := SchemaUpsertable{
 		SchemaCmd: &SchemaCmd{
 			SchemaOptions: &SchemaOptions{
 				Excludes: []string{"_test.go", "excludeme.go"},
@@ -341,9 +341,9 @@ func TestSchema_Check_Happy_New(t *testing.T) {
 			provideClient: provideClient,
 		},
 	}
-	schemaCheck.Args.Paths = []string{"../../testentity"}
+	schemaUpsertable.Args.Paths = []string{"../../testentity"}
 
-	err := schemaCheck.Execute(nil)
+	err := schemaUpsertable.Execute(nil)
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
Calling it `schema check` leads to confusion with the API method `CheckSchema`. If `CheckSchema` fails at service startup, people think they can debug the situation with `dosa schema check` -- which is not true.