### PR TITLE
index columns zero value is []string(nil) but not []string{}

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -172,7 +172,7 @@ type IndexDefinition struct {
 
 // Clone returns a deep copy of IndexDefinition
 func (id *IndexDefinition) Clone() *IndexDefinition {
-	columns := make([]string, len(id.Columns))
+	var columns []string
 	copy(columns, id.Columns)
 	return &IndexDefinition{
 		Key:     id.Key.Clone(),

--- a/entity_test.go
+++ b/entity_test.go
@@ -358,14 +358,12 @@ func getValidEntityDefinition() *dosa.EntityDefinition {
 						},
 					},
 				},
-				Columns: []string{},
 			},
 
 			"index2": {
 				Key: &dosa.PrimaryKey{
 					PartitionKeys: []string{"bar"},
 				},
-				Columns: []string{},
 			},
 		},
 		Columns: []*dosa.ColumnDefinition{


### PR DESCRIPTION
Why I am doing this change?
Here is the error messages in integration test after using this dosa version.
```
Err: \"incompatible schema: index \\\"searchbystr\\\" mismatch: (&{(strv, an_uuid_key ASC, strkey ASC, int64key ASC) []} vs &{(strv, an_uuid_key ASC, strkey ASC, int64key ASC) []})\",",
```
After print the struct variables to explore more.
```
index searchbystr mismatch: (Key: &{(strv, an_uuid_key ASC, strkey ASC, int64key ASC), Columns: []string{}} vs &{ Key: (strv, an_uuid_key ASC, strkey ASC, int64key ASC) , Columns: []string(nil)}
```
They are not deep equal.
After I debug throughout the whole lifecycle how the values change from DOSA cli to gateway to Schema service. I found out the value `Columns: nil` changed into `Columns: []string{}` right here.
https://sourcegraph.uberinternal.com/code.uber.internal/infra/dosa-gateway@1e2ac98c230a95b1a9762078b4545d233022ad8f/-/blob/datastore/cassandra/connector.go#L50
So the Clone API messed it up.

the zero value of index columns if it's not specified should be []string(nil)
https://github.com/uber-go/dosa/blob/master/entity_parser.go#L355