### PR TITLE
use append but not copy to clone

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -173,7 +173,9 @@ type IndexDefinition struct {
 // Clone returns a deep copy of IndexDefinition
 func (id *IndexDefinition) Clone() *IndexDefinition {
 	var columns []string
-	copy(columns, id.Columns)
+	for _, c := range id.Columns {
+		columns = append(columns, c)
+	}
 	return &IndexDefinition{
 		Key:     id.Key.Clone(),
 		Columns: columns,

--- a/entity_test.go
+++ b/entity_test.go
@@ -364,6 +364,7 @@ func getValidEntityDefinition() *dosa.EntityDefinition {
 				Key: &dosa.PrimaryKey{
 					PartitionKeys: []string{"bar"},
 				},
+				Columns: []string{"qux", "foo"},
 			},
 		},
 		Columns: []*dosa.ColumnDefinition{


### PR DESCRIPTION
```
var s = make([]int, 3)
n := copy(s, []int{0, 1, 2, 3}) // n == 3, s == []int{0, 1, 2}
```
`copy(dst, src []T) int`
The number of elements copied is the minimum of len(src) and len(dst).
https://golang.org/ref/spec#Appending_and_copying_slices

In our use case, copy is not the right way to clone.

**make test**
**go test -v --run TestClone**
