### PR TITLE
Add a 'defunct' tag for Index definitions that define the index is defunct or not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## v3.4.7 (unreleased)
- - Nothing changed yet
+ - Add optional 'defunct' tag to Index definitions
 
 ## v3.4.6 (2019-06-11)
  - use append but not copy to clone

--- a/entity.go
+++ b/entity.go
@@ -168,6 +168,7 @@ func (cd *ColumnDefinition) Clone() *ColumnDefinition {
 type IndexDefinition struct {
 	Key     *PrimaryKey
 	Columns []string
+	Defunct bool
 }
 
 // Clone returns a deep copy of IndexDefinition
@@ -176,9 +177,11 @@ func (id *IndexDefinition) Clone() *IndexDefinition {
 	for _, c := range id.Columns {
 		columns = append(columns, c)
 	}
+	defunct := id.Defunct
 	return &IndexDefinition{
 		Key:     id.Key.Clone(),
 		Columns: columns,
+		Defunct: defunct,
 	}
 }
 

--- a/entity_parser_key_parser_test.go
+++ b/entity_parser_key_parser_test.go
@@ -740,6 +740,7 @@ func TestIndexParse(t *testing.T) {
 		ExpectedIndexName string
 		PrimaryKey        *PrimaryKey
 		Columns           []string
+		Defunct           bool
 		Error             error
 	}{
 		{
@@ -959,10 +960,46 @@ func TestIndexParse(t *testing.T) {
 			Columns:        []string{"ok", "test", "hi"},
 			Error:          errors.New("index field SearchByKey with an invalid dosa index tag: columns=(ok, test, (hi),)"),
 		},
+		{
+			Tag:               "name=jj key=ok columns=(ok, test, hi,) defunct=true",
+			ExpectedIndexName: "jj",
+			PrimaryKey: &PrimaryKey{
+				PartitionKeys:  []string{"ok"},
+				ClusteringKeys: nil,
+			},
+			InputIndexName: "SearchByKey",
+			Columns:        []string{"ok", "test", "hi"},
+			Defunct:        true,
+			Error:          nil,
+		},
+		{
+			Tag:               "defunct = true name=jj key=ok columns=(ok, test, hi,)",
+			ExpectedIndexName: "jj",
+			PrimaryKey: &PrimaryKey{
+				PartitionKeys:  []string{"ok"},
+				ClusteringKeys: nil,
+			},
+			InputIndexName: "SearchByKey",
+			Columns:        []string{"ok", "test", "hi"},
+			Defunct:        true,
+			Error:          nil,
+		},
+		{
+			Tag:               "name=jj key=ok columns=(ok, test, hi,) defunct=false",
+			ExpectedIndexName: "jj",
+			PrimaryKey: &PrimaryKey{
+				PartitionKeys:  []string{"ok"},
+				ClusteringKeys: nil,
+			},
+			InputIndexName: "SearchByKey",
+			Columns:        []string{"ok", "test", "hi"},
+			Defunct:        false,
+			Error:          nil,
+		},
 	}
 
 	for _, d := range data {
-		name, primaryKey, columns, err := parseIndexTag(d.InputIndexName, d.Tag)
+		name, primaryKey, columns, defunct, err := parseIndexTag(d.InputIndexName, d.Tag)
 		if d.Error != nil {
 			assert.Contains(t, err.Error(), d.Error.Error())
 		} else {
@@ -970,6 +1007,7 @@ func TestIndexParse(t *testing.T) {
 			assert.Equal(t, name, d.ExpectedIndexName)
 			assert.Equal(t, primaryKey, d.PrimaryKey)
 			assert.Equal(t, columns, d.Columns)
+			assert.Equal(t, defunct, d.Defunct)
 		}
 	}
 }

--- a/entity_test.go
+++ b/entity_test.go
@@ -365,6 +365,7 @@ func getValidEntityDefinition() *dosa.EntityDefinition {
 					PartitionKeys: []string{"bar"},
 				},
 				Columns: []string{"qux", "foo"},
+				Defunct: true,
 			},
 		},
 		Columns: []*dosa.ColumnDefinition{

--- a/finder.go
+++ b/finder.go
@@ -263,14 +263,14 @@ func tableFromStructType(structName string, structType *ast.StructType, packageP
 			for _, fieldName := range field.Names {
 				name := fieldName.Name
 				if kind == packagePrefix+"."+indexName || (packagePrefix == "" && kind == indexName) {
-					indexName, indexKey, indexColumns, err := parseIndexTag(name, dosaTag)
+					indexName, indexKey, indexColumns, defunct, err := parseIndexTag(name, dosaTag)
 					if err != nil {
 						return nil, err
 					}
 					if _, exist := t.Indexes[indexName]; exist {
 						return nil, errors.Errorf("index name is duplicated: %s", indexName)
 					}
-					t.Indexes[indexName] = &IndexDefinition{Key: indexKey, Columns: indexColumns}
+					t.Indexes[indexName] = &IndexDefinition{Key: indexKey, Columns: indexColumns, Defunct: defunct}
 				} else {
 					firstRune, _ := utf8.DecodeRuneInString(name)
 					if unicode.IsLower(firstRune) {
@@ -293,14 +293,14 @@ func tableFromStructType(structName string, structType *ast.StructType, packageP
 
 			if len(field.Names) == 0 {
 				if kind == packagePrefix+"."+indexName || (packagePrefix == "" && kind == indexName) {
-					indexName, indexKey, indexColumns, err := parseIndexTag("", dosaTag)
+					indexName, indexKey, indexColumns, defunct, err := parseIndexTag("", dosaTag)
 					if err != nil {
 						return nil, err
 					}
 					if _, exist := t.Indexes[indexName]; exist {
 						return nil, errors.Errorf("index name is duplicated: %s", indexName)
 					}
-					t.Indexes[indexName] = &IndexDefinition{Key: indexKey, Columns: indexColumns}
+					t.Indexes[indexName] = &IndexDefinition{Key: indexKey, Columns: indexColumns, Defunct: defunct}
 				}
 			}
 		}

--- a/finder_test.go
+++ b/finder_test.go
@@ -77,6 +77,7 @@ func TestParser(t *testing.T) {
 		"complexindexes":                &ComplexIndexes{},
 		"scopemetadata":                 &ScopeMetadata{},
 		"indexeswithcolumnstag":         &IndexesWithColumnsTag{},
+		"indexeswithdefuncttag":         &IndexesWithDefunctTag{},
 	}
 	entitiesExcludedForTest := map[string]interface{}{
 		"clienttestentity1":      struct{}{}, // skip, see https://jira.uberinternal.com/browse/DOSA-788


### PR DESCRIPTION
Cassandra doesn’t support changing columns of the materialized view. Therefore It introduces the concern that how to handle the existing index table since the goal of the feature is to reduce the large partition.
The current solution is to educate users to mark their old index table as `defunct` and then create a new index table with limited columns. 
The next time users use range query, the gateway would skip the lookup in defunct index table.