### PR TITLE
handle the ignored error in CLI query codes

### DIFF
--- a/cmd/dosa/client.go
+++ b/cmd/dosa/client.go
@@ -61,7 +61,11 @@ func (c *shellQueryClient) GetRegistrar() dosa.Registrar {
 
 func (c *shellQueryClient) Initialize(ctx context.Context) error {
 	registar := c.GetRegistrar()
-	reg, _ := registar.Find(&dosa.Entity{})
+	reg, err := registar.Find(&dosa.Entity{})
+	// this error should never happen for CLI query cases
+	if err != nil {
+		return errors.New("Error finding dosa entities")
+	}
 
 	version, err := c.connector.CheckSchema(ctx, registar.Scope(), registar.NamePrefix(), []*dosa.EntityDefinition{reg.EntityDefinition()})
 	if err != nil {

--- a/cmd/dosa/query.go
+++ b/cmd/dosa/query.go
@@ -86,7 +86,11 @@ func (c *QueryCmd) doQueryOp(f func(ShellQueryClient, context.Context, []*queryO
 		return err
 	}
 
-	re, _ := client.GetRegistrar().Find(&dosa.Entity{})
+	re, err := client.GetRegistrar().Find(&dosa.Entity{})
+	// this error should never happen for CLI query cases
+	if err != nil {
+		return err
+	}
 
 	fvs, err := setQueryFieldValues(kvs, re)
 	if err != nil {

--- a/cmd/dosa/range.go
+++ b/cmd/dosa/range.go
@@ -30,7 +30,11 @@ import (
 // Range uses the connector to fetch rows for a given range
 func (c *shellQueryClient) Range(ctx context.Context, ops []*queryObj, fields []string, limit int) ([]map[string]dosa.FieldValue, error) {
 	// look up the entity in the registry
-	re, _ := c.registrar.Find(&dosa.Entity{})
+	re, err := c.registrar.Find(&dosa.Entity{})
+	// this error should never happen for CLI query cases
+	if err != nil {
+		return nil, err
+	}
 
 	// build range operator with expressions and limit number
 	r, err := buildRangeOp(ops, limit)

--- a/cmd/dosa/read.go
+++ b/cmd/dosa/read.go
@@ -30,7 +30,11 @@ import (
 // Read fetches a row by primary key.
 func (c *shellQueryClient) Read(ctx context.Context, ops []*queryObj, fields []string, limit int) ([]map[string]dosa.FieldValue, error) {
 	// look up entity in the registry
-	re, _ := c.registrar.Find(&dosa.Entity{})
+	re, err := c.registrar.Find(&dosa.Entity{})
+	// this error should never happen for CLI query cases
+	if err != nil {
+		return nil, err
+	}
 
 	// build arguments for read with expressions
 	fvs, err := buildReadArgs(ops)


### PR DESCRIPTION
There are some ignored errors in the CLI query code. Although those errors will never happen, we should handle them to achieve the best practices in GO.