### PR TITLE
don't allow whitespace beside equal sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## v3.4.7 (unreleased)
- - Nothing changed yet
+ - don't allow whitespace beside equal sign
 
 ## v3.4.6 (2019-06-11)
  - use append but not copy to clone

--- a/entity_parser.go
+++ b/entity_parser.go
@@ -40,20 +40,20 @@ const (
 )
 
 var (
-	primaryKeyPattern0 = regexp.MustCompile(`primaryKey\s*=\s*([^=]*)((\s+.*=)|$)`)
+	primaryKeyPattern0 = regexp.MustCompile(`primaryKey=([^=]*)((\s+.*=)|$)`)
 	primaryKeyPattern1 = regexp.MustCompile(`\(\s*\((.*)\)(.*)\)`)
 	primaryKeyPattern2 = regexp.MustCompile(`\(\s*([^,\s]+),?(.*)\)`)
 	primaryKeyPattern3 = regexp.MustCompile(`^\s*([^(),\s]+)\s*$`)
 
-	indexKeyPattern0 = regexp.MustCompile(`key\s*=\s*([^=]*)((\s+.*=)|$)`)
+	indexKeyPattern0 = regexp.MustCompile(`key=([^=]*)((\s+.*=)|$)`)
 
-	namePattern0 = regexp.MustCompile(`name\s*=\s*(\S*)`)
+	namePattern0 = regexp.MustCompile(`name=(\S*)`)
 
-	columnsPattern = regexp.MustCompile(`columns\s*=\s*\(([^\(\)]+)\)`)
+	columnsPattern = regexp.MustCompile(`columns=\(([^\(\)]+)\)`)
 
-	etlPattern0 = regexp.MustCompile(`etl\s*=\s*(\S*)`)
+	etlPattern0 = regexp.MustCompile(`etl=(\S*)`)
 
-	ttlPattern0 = regexp.MustCompile(`ttl\s*=\s*(\S*)`)
+	ttlPattern0 = regexp.MustCompile(`ttl=(\S*)`)
 
 	indexType = reflect.TypeOf((*Index)(nil)).Elem()
 )

--- a/entity_parser_key_parser_test.go
+++ b/entity_parser_key_parser_test.go
@@ -608,7 +608,7 @@ func TestEntityParse(t *testing.T) {
 			TTL:   NoTTL(),
 		},
 		{
-			Tag:       "name=jj primaryKey=ok etl=OFF, ttl = 90h",
+			Tag:       "name=jj primaryKey=ok etl=OFF, ttl=90h",
 			TableName: "jj",
 			PrimaryKey: &PrimaryKey{
 				PartitionKeys:  []string{"ok"},
@@ -619,13 +619,13 @@ func TestEntityParse(t *testing.T) {
 			TTL:   time.Hour * 90,
 		},
 		{
-			Tag:       "name=jj primaryKey=ok etl=Off, ttl = 912ms",
+			Tag:       "name=jj primaryKey=ok etl=Off, ttl=912ms",
 			TableName: "jj",
 			PrimaryKey: &PrimaryKey{
 				PartitionKeys:  []string{"ok"},
 				ClusteringKeys: nil,
 			},
-			Error: errors.New("invalid ttl tag:    ttl = 912ms: TTL is not allowed to set less than 1 second"),
+			Error: errors.New("invalid ttl tag:    ttl=912ms: TTL is not allowed to set less than 1 second"),
 			ETL:   EtlOff,
 			TTL:   time.Millisecond * 912,
 		},


### PR DESCRIPTION
It's unreasonable to allow whitespace beside `=` which leads to a tough parsing and messy syntax.
Lucky enough, after searching all the tags such as `Entity.*ttl\s` in sourcegraph, the uber codebase doesn't have one bad example that users put space beside `=`, before it is getting out of control,  refactor to get strict rule .