### PR TITLE
Cleanup String methods, and do not use reflect.DeepEqual to compare entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## v3.4.8 (unreleased)
+## v3.4.9 (unreleased)
  - Nothing changed yet
+
+## v3.4.8 (2019-07-26)
+ - CheckSchema needs to compare schemas carefully, and not just use reflect.DeepEqual
 
 ## v3.4.7 (2019-07-22)
  - Add String() method to all components of the routing connector

--- a/connectors/routing/config.go
+++ b/connectors/routing/config.go
@@ -106,7 +106,7 @@ func (r *routers) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				if !ok {
 					return fmt.Errorf("failed to parse the config: %v", namePrefixesMap)
 				}
-				router, err := NewRule(scope, namePrefixStr, connectorName)
+				router, err := newRule(scope, namePrefixStr, connectorName)
 				if err != nil {
 					return errors.Wrap(err, "failed to parse routing config")
 				}

--- a/connectors/routing/config_test.go
+++ b/connectors/routing/config_test.go
@@ -101,7 +101,7 @@ func TestBasicConfig(t *testing.T) {
 }
 
 func buildRule(scope, namePrefix, connector string) *rule {
-	rc, _ := NewRule(scope, namePrefix, connector)
+	rc, _ := newRule(scope, namePrefix, connector)
 	return rc
 }
 

--- a/connectors/routing/routing_config.go
+++ b/connectors/routing/routing_config.go
@@ -41,8 +41,8 @@ type rule struct {
 	canonPfx   string
 }
 
-// NewRule creates a rule.
-func NewRule(scope, namePrefix, connector string) (*rule, error) {
+// newRule creates a rule.
+func newRule(scope, namePrefix, connector string) (*rule, error) {
 	// scope must be a valid name, optionally with a suffix *. namePrefix must be a valid prefix name,
 	// optionally with a suffix *.
 	if scope == "" {

--- a/connectors/routing/routing_config_test.go
+++ b/connectors/routing/routing_config_test.go
@@ -28,29 +28,29 @@ import (
 )
 
 func TestNewRoutingConfig(t *testing.T) {
-	rConfig, err := NewRule("production", "test", "memory")
+	rConfig, err := newRule("production", "test", "memory")
 	assert.Nil(t, err)
 	assert.Equal(t, rConfig.namePrefix, "test")
 }
 
 func TestNewRoutingConfigWithStarPrefix(t *testing.T) {
-	rConfig, err := NewRule("production", "*.v1", "memory")
+	rConfig, err := newRule("production", "*.v1", "memory")
 	assert.Nil(t, rConfig)
 	assert.Contains(t, err.Error(), "invalid")
 }
 
 func TestTestNewRoutingConfigError(t *testing.T) {
-	rConfig, err := NewRule("production", "", "memory")
+	rConfig, err := newRule("production", "", "memory")
 	assert.Nil(t, rConfig)
 	assert.Contains(t, err.Error(), "cannot be empty")
 
-	rConfig, err = NewRule("", "test", "memory")
+	rConfig, err = newRule("", "test", "memory")
 	assert.Nil(t, rConfig)
 	assert.Contains(t, err.Error(), "scope cannot be empty")
 }
 
 func TestString(t *testing.T) {
-	r, err := NewRule("production", "test", "memory")
+	r, err := newRule("production", "test", "memory")
 	assert.Nil(t, err)
 	assert.Equal(t, "{production.test -> memory}", r.String())
 }

--- a/entity_test.go
+++ b/entity_test.go
@@ -553,3 +553,26 @@ func TestClone(t *testing.T) {
 	ed1 := ed.Clone()
 	assert.Equal(t, ed, ed1)
 }
+
+func TestColumnDefinitionPrint(t *testing.T) {
+	cd := dosa.ColumnDefinition{
+		Name:      "foo",
+		Type:      dosa.TUUID,
+		IsPointer: true,
+		Tags: map[string]string{
+			"e": "bar1",
+			"c": "bar2",
+			"a": "bar3",
+			"b": "bar4",
+			"d": "bar5",
+		},
+	}
+	assert.Equal(t, "{Name: foo, Type: TUUID, IsPointer: true, Tags: {a: bar3, b: bar4, c: bar2, d: bar5, e: bar1}}",
+		cd.String())
+
+	cd = dosa.ColumnDefinition{
+		Name: "bar",
+		Type: dosa.Int64,
+	}
+	assert.Equal(t, "{Name: bar, Type: Int64, IsPointer: false, Tags: {}}", cd.String())
+}

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package dosa
 
 // VERSION indicates the dosa client version
-const VERSION = "3.4.7"
+const VERSION = "3.4.8"


### PR DESCRIPTION
Instead of `reflect.DeepEqual` use sensible comparisons.
Also made `newRule` package-private to remove a lint check.