### PR TITLE
Update 'scope drop' success message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v3.4.9 (unreleased)
+ - clarifying message on success of scope drop, to wait before re-creating
  - modify the test cases using space as the delimiter between tags
 
 ## v3.4.8 (2019-07-26)

--- a/cmd/dosa/scope.go
+++ b/cmd/dosa/scope.go
@@ -57,6 +57,9 @@ func (c *ScopeCmd) doScopeOp(name string, f func(dosa.AdminClient, context.Conte
 			return errors.Wrapf(err, "%s scope on %q", name, s)
 		}
 		fmt.Printf("%s scope %q: OK\n", name, s)
+		if name == "drop" {
+			fmt.Println("\nPlease wait 10 minutes if you are going to re-create the scope with the same name.\n")	
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
On scope drop success, print a message reminding the user that they need to wait 10 minutes before re-creating the scope with the same name.