### PR TITLE
Routing: public method to map (scope,prefix) to a cluster name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v3.4.9 (unreleased)
  - modify the test cases using space as the delimiter between tags
+ - expose a method Resolve(scope,prefix) -> cluster
 
 ## v3.4.8 (2019-07-26)
  - Add transport parameter to yarpc connector and cli

--- a/connectors/routing/connector.go
+++ b/connectors/routing/connector.go
@@ -49,9 +49,14 @@ func (rc *Connector) String() string {
 	return fmt.Sprintf("[Routing %s]", rc.config.String())
 }
 
+// Resolve returns the destination engine for the given scope and name-prefix.
+func (rc *Connector) Resolve(scope, namePrefix string) string {
+	return rc.config.getEngineName(scope, namePrefix)
+}
+
 // get connector by scope and namePrefix
 func (rc *Connector) getConnector(scope, namePrefix string) (dosa.Connector, error) {
-	connName := rc.config.getEngineName(scope, namePrefix)
+	connName := rc.Resolve(scope, namePrefix)
 	c, ok := rc.connectors[connName]
 	if !ok {
 		return nil, fmt.Errorf("can't find %q connector", connName)

--- a/connectors/routing/resolver.go
+++ b/connectors/routing/resolver.go
@@ -1,0 +1,6 @@
+package routing
+
+type Resolver interface {
+  // Resolve maps a (scope, prefix) to a cluster name.
+  Resolve(scope, namePrefix string) string
+}

--- a/connectors/routing/resolver.go
+++ b/connectors/routing/resolver.go
@@ -1,5 +1,6 @@
 package routing
 
+// Resolver is an object that knows about the map from (scope,prefix) to cluster.
 type Resolver interface {
   // Resolve maps a (scope, prefix) to a cluster name.
   Resolve(scope, namePrefix string) string


### PR DESCRIPTION
No change to functionality.