### PR TITLE
Allow the function pointer to be nil in EnsureValidRangeConditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## v3.4.10 (unreleased)
- - Nothing changed yet.
+ - Allow nil transform-function in EnsureaValidRangeConditions
 
 ## v3.4.9 (2019-10-04)
  - clarifying message on success of scope drop, to wait before re-creating

--- a/connectors/routing/resolver.go
+++ b/connectors/routing/resolver.go
@@ -2,6 +2,6 @@ package routing
 
 // Resolver is an object that knows about the map from (scope,prefix) to cluster.
 type Resolver interface {
-  // Resolve maps a (scope, prefix) to a cluster name.
-  Resolve(scope, namePrefix string) string
+	// Resolve maps a (scope, prefix) to a cluster name.
+	Resolve(scope, namePrefix string) string
 }

--- a/connectors/routing/resolver.go
+++ b/connectors/routing/resolver.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package routing
 
 // Resolver is an object that knows about the map from (scope,prefix) to cluster.

--- a/entity.go
+++ b/entity.go
@@ -561,7 +561,7 @@ func stringSliceEqual(a, b []string) bool {
 
 func deterministicPrintMap(m map[string]string) string {
 	keys := make([]string, 0, len(m))
-	for k, _ := range m {
+	for k := range m {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)

--- a/range.go
+++ b/range.go
@@ -148,10 +148,9 @@ func (r *RangeOp) LimitRows() int {
 // IndexFromConditions returns the name of the index or the base table to use, along with the key info
 // for that index. If no suitable index could be found, an error is returned
 func (ei *EntityInfo) IndexFromConditions(conditions map[string][]*Condition, searchIndexes bool) (name string, key *PrimaryKey, err error) {
-	identityFunc := func(s string) string { return s }
 	// see if we match the primary key for this table
 	var baseTableError error
-	if baseTableError = EnsureValidRangeConditions(ei.Def, ei.Def.Key, conditions, identityFunc); baseTableError == nil {
+	if baseTableError = EnsureValidRangeConditions(ei.Def, ei.Def.Key, conditions, nil); baseTableError == nil {
 		return ei.Def.Name, ei.Def.Key, nil
 	}
 	if searchIndexes == false || len(ei.Def.Indexes) == 0 {
@@ -162,7 +161,7 @@ func (ei *EntityInfo) IndexFromConditions(conditions map[string][]*Condition, se
 	for name, indexDef = range ei.Def.Indexes {
 		key = indexDef.Key
 		// we check the range conditions before adding the uniqueness columns
-		if err := EnsureValidRangeConditions(ei.Def, key, conditions, identityFunc); err == nil {
+		if err := EnsureValidRangeConditions(ei.Def, key, conditions, nil); err == nil {
 			return name, ei.Def.UniqueKey(key), nil
 		}
 	}

--- a/range_conditions.go
+++ b/range_conditions.go
@@ -81,6 +81,10 @@ func EnsureValidRangeConditions(ed *EntityDefinition, pk *PrimaryKey, columnCond
 	//     partition key: each field must be present, with a single Eq constraint on each
 	//     clustering key: conditions must be applied to consecutive fields and must all be Eq except for the last one
 
+	if transform == nil {
+		transform = func(s string) string { return s }
+	}
+
 	// Get the partition key. Fields will be removed from missingPKs as we find them in columnConditions.
 	partitionKeys := pk.PartitionKeySet()
 	missingPKs := pk.PartitionKeySet()


### PR DESCRIPTION
There is absolutely no reason to have _N_ versions of the identity transform function.