### PR TITLE
Add the concept of a table alias for an index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v3.4.11 (unreleased)
  - Improve yarpc connector naming, differentiate goyarpc from dosarpc
  - Improve the error message if name is invalid
+ - Add TableName to IndexDefinition
 
 ## v3.4.10 (2019-10-14)
  - Allow nil transform-function in EnsureValidRangeConditions

--- a/entity.go
+++ b/entity.go
@@ -205,8 +205,9 @@ func (cd *ColumnDefinition) String() string {
 
 // IndexDefinition stores information about a DOSA entity's index
 type IndexDefinition struct {
-	Key     *PrimaryKey
-	Columns []string
+	Key       *PrimaryKey
+	Columns   []string
+	TableName string
 }
 
 // Clone returns a deep copy of IndexDefinition

--- a/entity.go
+++ b/entity.go
@@ -205,9 +205,9 @@ func (cd *ColumnDefinition) String() string {
 
 // IndexDefinition stores information about a DOSA entity's index
 type IndexDefinition struct {
-	Key       *PrimaryKey
-	Columns   []string
-	TableName string
+	Key        *PrimaryKey
+	Columns    []string
+	TableAlias string // May be empty
 }
 
 // Clone returns a deep copy of IndexDefinition

--- a/entity.go
+++ b/entity.go
@@ -205,9 +205,9 @@ func (cd *ColumnDefinition) String() string {
 
 // IndexDefinition stores information about a DOSA entity's index
 type IndexDefinition struct {
-	Key        *PrimaryKey
-	Columns    []string
-	TableAlias string // May be empty
+	Key       *PrimaryKey
+	Columns   []string
+	TableName string // May be empty
 }
 
 // Clone returns a deep copy of IndexDefinition


### PR DESCRIPTION
Docstore does not implement index aliases yet.