### PR TITLE
Better CLI errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## v3.4.12 (unreleased)
+## v3.4.13 (unreleased)
  - Nothing changed yet.
+
+## v3.4.12 (2019-12-06)
+ - Improve some CLI error messages
 
 ## v3.4.11 (2019-11-01)
  - Improve yarpc connector naming, differentiate goyarpc from dosarpc

--- a/cmd/dosa/schema.go
+++ b/cmd/dosa/schema.go
@@ -150,6 +150,10 @@ func (c *SchemaCmd) doSchemaOp(name string, f func(dosa.AdminClient, context.Con
 	}
 	fmt.Printf("Version: %d\n", status.Version)
 	fmt.Printf("Status: %s\n", status.Status)
+	if strings.Contains(status.Status, "upgrade workflow is already in progress") {
+		fmt.Printf("Please re-try in ten minutes; if you get the same error, ask the DOSA oncaller to cancel the workflow.")
+	}
+
 	return nil
 }
 

--- a/connectors/yarpc/yarpc.go
+++ b/connectors/yarpc/yarpc.go
@@ -216,15 +216,15 @@ func (c *Connector) CreateIfNotExists(ctx context.Context, ei *dosa.EntityInfo, 
 	if err != nil {
 		if be, ok := err.(*dosarpc.BadRequestError); ok {
 			if be.ErrorCode != nil && *be.ErrorCode == errCodeAlreadyExists {
-				return errors.Wrap(&dosa.ErrAlreadyExists{}, "failed to create")
+				return errors.Wrap(&dosa.ErrAlreadyExists{}, "CreateIfNotExists failed")
 			}
 		}
 
 		if !dosarpc.Dosa_CreateIfNotExists_Helper.IsException(err) {
-			return errors.Wrap(err, "failed to CreateIfNotExists due to network issue")
+			return errors.Wrap(err, "CreateIfNotExists failed due to network issue")
 		}
 	}
-	return errors.Wrap(err, "failed to CreateIfNotExists")
+	return errors.Wrap(err, "CreateIfNotExists failed")
 }
 
 // Upsert inserts or updates your data
@@ -597,9 +597,9 @@ func (c *Connector) CanUpsertSchema(ctx context.Context, scope, namePrefix strin
 	response, err := c.client.CanUpsertSchema(ctx, &csr, getHeaders(c.headers)...)
 	if err != nil {
 		if !dosarpc.Dosa_CanUpsertSchema_Helper.IsException(err) {
-			return dosa.InvalidVersion, errors.Wrap(err, "failed to CanUpsertSchema due to network issue")
+			return dosa.InvalidVersion, errors.Wrap(err, "CanUpsertSchema failed due to network issue")
 		}
-		return dosa.InvalidVersion, wrapError(err, "failed to CanUpsertSchema")
+		return dosa.InvalidVersion, wrapError(err, "CanUpsertSchema failed")
 	}
 
 	return *response.Version, nil

--- a/connectors/yarpc/yarpc.go
+++ b/connectors/yarpc/yarpc.go
@@ -340,8 +340,7 @@ func (c *Connector) Read(ctx context.Context, ei *dosa.EntityInfo, keys map[stri
 		return nil, errors.Wrap(err, "failed to Read")
 	}
 
-	// no error, so for each column, transform it into the map of (col->value) items
-
+	// no error, so transform the row into a map colname->value
 	return decodeResults(ei, response.EntityValues), nil
 }
 
@@ -515,9 +514,7 @@ func (c *Connector) Range(ctx context.Context, ei *dosa.EntityInfo, columnCondit
 func createRPCConditions(columnConditions map[string][]*dosa.Condition) ([]*dosarpc.Condition, error) {
 	rpcConditions := []*dosarpc.Condition{}
 	for field, conditions := range columnConditions {
-		// Warning: Don't remove this line.
-		// field variable always has the same address. If we want to dereference it, we have to assign the value to a new variable.
-		fieldName := field
+		fieldName := field // Warning: see https://github.com/golang/go/issues/20725.
 		for _, condition := range conditions {
 			rv, err := RawValueFromInterface(condition.Value)
 			if err != nil {

--- a/connectors/yarpc/yarpc.go
+++ b/connectors/yarpc/yarpc.go
@@ -577,7 +577,7 @@ func (c *Connector) CheckSchema(ctx context.Context, scope, namePrefix string, e
 			return dosa.InvalidVersion, errors.Wrap(err, "failed to CheckSchema due to network issue")
 		}
 
-		return dosa.InvalidVersion, wrapError(err, "failed to CheckSchema", scope)
+		return dosa.InvalidVersion, wrapError(err, "failed to CheckSchema")
 	}
 
 	return *response.Version, nil
@@ -599,7 +599,7 @@ func (c *Connector) CanUpsertSchema(ctx context.Context, scope, namePrefix strin
 		if !dosarpc.Dosa_CanUpsertSchema_Helper.IsException(err) {
 			return dosa.InvalidVersion, errors.Wrap(err, "failed to CanUpsertSchema due to network issue")
 		}
-		return dosa.InvalidVersion, wrapError(err, "failed to CanUpsertSchema", scope)
+		return dosa.InvalidVersion, wrapError(err, "failed to CanUpsertSchema")
 	}
 
 	return *response.Version, nil
@@ -619,7 +619,7 @@ func (c *Connector) UpsertSchema(ctx context.Context, scope, namePrefix string, 
 		if !dosarpc.Dosa_UpsertSchema_Helper.IsException(err) {
 			return nil, errors.Wrap(err, "failed to UpsertSchema due to network issue")
 		}
-		return nil, wrapError(err, "failed to UpsertSchema", scope)
+		return nil, wrapError(err, "failed to UpsertSchema")
 	}
 
 	status := ""
@@ -644,10 +644,10 @@ func (c *Connector) CheckSchemaStatus(ctx context.Context, scope, namePrefix str
 
 	if err != nil {
 		if !dosarpc.Dosa_CheckSchemaStatus_Helper.IsException(err) {
-			return nil, errors.Wrap(err, "failed to CheckSchemaStatus due to network issue")
+			return nil, errors.Wrap(err, "CheckSchemaStatus failed due to network issue")
 		}
 
-		return nil, wrapError(err, "failed to CheckSchemaStatus", scope)
+		return nil, wrapError(err, "CheckSchemaStatus failed")
 	}
 
 	status := ""
@@ -656,7 +656,7 @@ func (c *Connector) CheckSchemaStatus(ctx context.Context, scope, namePrefix str
 	}
 
 	if response.Version == nil {
-		return nil, errors.New("failed to ChecksShemaStatus: server returns version nil")
+		return nil, errors.New("CheckShemaStatus failed: server returned unknown version")
 	}
 
 	return &dosa.SchemaStatus{
@@ -747,7 +747,7 @@ func (c *Connector) Shutdown() error {
 	return c.dispatcher.Stop()
 }
 
-func wrapError(err error, message, scope string) error {
+func wrapError(err error, message string) error {
 	if ErrorIsConnectionRefused(err) {
 		err = &ErrConnectionRefused{err}
 	}

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package dosa
 
 // VERSION indicates the dosa client version
-const VERSION = "3.4.11"
+const VERSION = "3.4.12"


### PR DESCRIPTION
The CLI needs to be released, v3.4.2 is now pretty old....

Also removed unused argument in `wrapError()` in the yarpc connector.