### PR TITLE
Fix bug in ETL parsing

### DIFF
--- a/entity_parser.go
+++ b/entity_parser.go
@@ -386,14 +386,8 @@ func parseETLTag(tag string) (string, ETLState, error) {
 		return "", EtlOff, nil
 	}
 
-	// filter out "trailing comma"
-	etlTag = strings.TrimRight(etlTag, " ,")
-
-	var err error
-	etlTag, err = NormalizeName(etlTag)
-	if err != nil {
-		return "", EtlOff, err
-	}
+	// filter out "trailing comma" and convert to lowercase
+	etlTag = strings.ToLower(strings.TrimRight(etlTag, " ,"))
 
 	etlState, err := ToETLState(etlTag)
 	if err != nil {

--- a/names.go
+++ b/names.go
@@ -54,8 +54,8 @@ func init() {
 		"of", "on", "one", "order", "partition", "password", "per", "permission", "permissions",
 		"primary", "quorum", "rename", "revoke", "schema", "select", "set", "static", "storage",
 		"superuser", "table", "text", "time", "timestamp", "timeuuid", "three", "to", "token",
-		"truncate", "ttl", "tuple", "two", "type", "unlogged", "update", "use", "user", "users",
-		"using", "uuid", "values", "varchar", "varint", "view", "where", "with", "writetime"}
+		"truncate", "ttl", "tuple", "two", "unlogged", "update", "use", "user", "users",
+		"using", "values", "varchar", "varint", "view", "where", "with", "writetime"}
 	reserved = make(map[string]struct{})
 	for _, n := range cassandraRsvd {
 		reserved[n] = struct{}{}
@@ -83,7 +83,7 @@ func IsValidName(name string) error {
 	if _, ok := reserved[name]; !ok {
 		return nil
 	}
-	return errors.Errorf("%s is a reserved word", name)
+	return errors.Errorf("'%s' is a reserved word", name)
 }
 
 // NormalizeName normalizes a name to a canonical representation.


### PR DESCRIPTION
`NormalizeName` is completely the wrong thing to use, an ETL tag is not necessarily a "name": `on` is a reserved word is not a legal name!

Also discovered that the list of reserved words is not really definitive: `uuid` and `type` are both on the "reserved" list but are fine as field names; but we know `token` is definitely not OK.