### PR TITLE
Update version to 3.4.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
-## v3.4.16 (unreleased)
+## v3.4.17 (unreleased)
+ - No changes yet.
+
+## v3.4.16 (2020-01-31)
  - Update to IDL 3.3 for column ordering
+ - Send column order with all schema requests
 
 ## v3.4.15 (2020-01-07)
  - Update the Cassandra reserved-word list (old list included non-reserved keywords).

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package dosa
 
 // VERSION indicates the dosa client version
-const VERSION = "3.4.15"
+const VERSION = "3.4.16"


### PR DESCRIPTION
v3.4.16 sends column order with all schema definitions.