### PR TITLE
Make thrift decode of EntityDefinition respect column ordering.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## v3.4.17 (unreleased)
+## v3.4.18 (unreleased)
  - No changes yet.
+
+## v3.4.17 (2020-01-31)
+ - Make thrift decode of EntityDefinition respect column ordering.
 
 ## v3.4.16 (2020-01-31)
  - Update to IDL 3.3 for column ordering

--- a/connectors/yarpc/helpers_test.go
+++ b/connectors/yarpc/helpers_test.go
@@ -247,3 +247,9 @@ func TestGetHeaders(t *testing.T) {
 		assert.Equal(t, "yarpc.CallOption", reflect.TypeOf(h).String())
 	}
 }
+
+func TestColumnOrder(t *testing.T) {
+	rpcEDs := EntityDefsToThrift([]*dosa.EntityDefinition{testEntityDefinition})
+	dosaEd := FromThriftToEntityDefinition(rpcEDs[0])
+	assert.Equal(t, dosaEd.Columns, testEntityDefinition.Columns)
+}

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package dosa
 
 // VERSION indicates the dosa client version
-const VERSION = "3.4.16"
+const VERSION = "3.4.17"


### PR DESCRIPTION
Should have included this in the previous diff (facepalm)....