### PR TITLE
Preserve Operator.String(), add Operator.Symbol()

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -268,6 +268,23 @@ func (f ScopeFlagType) String() string {
 func (op Operator) String() string {
 	switch op {
 	case Eq:
+		return "Eq"
+	case Lt:
+		return "Lt"
+	case LtOrEq:
+		return "LtOrEq"
+	case Gt:
+		return "Gt"
+	case GtOrEq:
+		return "GtOrEq"
+	default:
+		return "?"
+	}
+}
+
+func (op Operator) Symbol() string {
+	switch op {
+	case Eq:
 		return "=="
 	case Lt:
 		return "<"

--- a/range_conditions.go
+++ b/range_conditions.go
@@ -43,7 +43,7 @@ type ColumnCondition struct {
 }
 
 func (cc *ColumnCondition) String() string {
-	return fmt.Sprintf("(%s %v %v)", cc.Name, cc.Condition.Op, cc.Condition.Value)
+	return fmt.Sprintf("(%s %s %v)", cc.Name, cc.Condition.Op.Symbol(), cc.Condition.Value)
 }
 
 // SortedColumnCondition implements sorting of an array of columnConditions


### PR DESCRIPTION
There are many gateway tests which depend on `Operator.String()` returning `Eq` etc., so put that back, and define `Symbol()` to return the symbolic operators.