### PR TITLE
Add cache configuration per endpoint in fallback cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v3.4.27 (unreleased)
+## v3.4.26 (unreleased)
  - Add cache configuration per endpoint in fallback cache
 
 ## v3.4.26 (unreleased)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,6 @@
 ## v3.4.26 (unreleased)
  - Add cache configuration per endpoint in fallback cache
 
-## v3.4.26 (unreleased)
- - Nothing changed yet.
-
 ## v3.4.25 (2020-05-05)
  - Add the RateLimit error.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v3.4.27 (unreleased)
+ - Add cache configuration per endpoint in fallback cache
+
 ## v3.4.26 (unreleased)
  - Nothing changed yet.
 

--- a/connectors/cache/fallback.go
+++ b/connectors/cache/fallback.go
@@ -61,24 +61,24 @@ func WithSkipWriteInvalidateEntities(entities ...dosa.DomainObject) Options {
 }
 
 type ContextKey string
+
 // Context key used by SetCacheableEndpoints
 var (
 	// ContextEndpoint allows users to pass in calling endpoint name
 	ContextEndpoint ContextKey = "endpoint"
->>>>>>> TEst
 	// EndpointActiveStatus marks the endpoint as active
 	EndpointActiveStatus bool = true
 )
 
 // SetContextEndpoint set endpoint in context
 func SetContextEndpoint(ctx context.Context, endpoint string) context.Context {
-    return context.WithValue(ctx, ContextEndpoint, endpoint)
+	return context.WithValue(ctx, ContextEndpoint, endpoint)
 }
 
 // GetContextEndpoint get endpoint from context
 func GetContextEndpoint(ctx context.Context) string {
-    endpoint, _ := ctx.Value(ContextEndpoint).(string)
-    return endpoint
+	endpoint, _ := ctx.Value(ContextEndpoint).(string)
+	return endpoint
 }
 
 // SetCacheableEndpoints sets cacheable endpoints

--- a/connectors/cache/fallback.go
+++ b/connectors/cache/fallback.go
@@ -23,7 +23,6 @@ package cache
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -61,25 +60,31 @@ func WithSkipWriteInvalidateEntities(entities ...dosa.DomainObject) Options {
 	}
 }
 
+type ContextKey string
 // Context key used by SetCacheableEndpoints
 var (
 	// ContextEndpoint allows users to pass in calling endpoint name
-	ContextEndpoint string = "endpoint"
+	ContextEndpoint ContextKey = "endpoint"
+>>>>>>> TEst
 	// EndpointActiveStatus marks the endpoint as active
 	EndpointActiveStatus bool = true
 )
+
+// SetContextEndpoint set endpoint in context
+func SetContextEndpoint(ctx context.Context, endpoint string) context.Context {
+    return context.WithValue(ctx, ContextEndpoint, endpoint)
+}
+
+// GetContextEndpoint get endpoint from context
+func GetContextEndpoint(ctx context.Context) string {
+    endpoint, _ := ctx.Value(ContextEndpoint).(string)
+    return endpoint
+}
 
 // SetCacheableEndpoints sets cacheable endpoints
 func SetCacheableEndpoints(endpoints ...string) Options {
 	return func(c *Connector) error {
 		for _, endpoint := range endpoints {
-			fmt.Print("!!!!!!!!!!!!!!!!!1111")
-			fmt.Print("!!!!!!!!!!!!!!!!!1111")
-			fmt.Print("!!!!!!!!!!!!!!!!!1111")
-			fmt.Printf("SetCacheableEndpoints Setting Endpoint: %s", endpoint)
-			fmt.Print("!!!!!!!!!!!!!!!!!1111")
-			fmt.Print("!!!!!!!!!!!!!!!!!1111")
-			fmt.Print("!!!!!!!!!!!!!!!!!1111")
 			c.cacheableEndpointStatus[endpoint] = EndpointActiveStatus
 		}
 		return nil
@@ -453,14 +458,7 @@ func (c *Connector) isEndpointCacheable(ctx context.Context) bool {
 		return true
 	}
 
-	endpoint, _ := ctx.Value(ContextEndpoint).(string)
-	fmt.Print("!!!!!!!!!!!!!!!!!222")
-	fmt.Print("!!!!!!!!!!!!!!!!!222")
-	fmt.Print("!!!!!!!!!!!!!!!!!222")
-	fmt.Printf("isEndpointCacheable Checking Endpoint: %s", endpoint)
-	fmt.Print("!!!!!!!!!!!!!!!!!222")
-	fmt.Print("!!!!!!!!!!!!!!!!!222")
-	fmt.Print("!!!!!!!!!!!!!!!!!222")
+	endpoint := GetContextEndpoint(ctx)
 	return c.cacheableEndpointStatus[endpoint]
 }
 

--- a/connectors/cache/fallback.go
+++ b/connectors/cache/fallback.go
@@ -60,24 +60,24 @@ func WithSkipWriteInvalidateEntities(entities ...dosa.DomainObject) Options {
 	}
 }
 
-type ContextKey string
+// contextKey used by SetCacheableEndpoints to set endpoint names
+type contextKey string
 
-// Context key used by SetCacheableEndpoints
 var (
-	// ContextEndpoint allows users to pass in calling endpoint name
-	ContextEndpoint ContextKey = "endpoint"
-	// EndpointActiveStatus marks the endpoint as active
-	EndpointActiveStatus bool = true
+	// contextEndpoint allows users to pass in calling endpoint name
+	contextEndpoint contextKey = "endpoint"
+	// endpointActiveStatus marks the endpoint as active
+	endpointActiveStatus bool = true
 )
 
 // SetContextEndpoint set endpoint in context
 func SetContextEndpoint(ctx context.Context, endpoint string) context.Context {
-	return context.WithValue(ctx, ContextEndpoint, endpoint)
+	return context.WithValue(ctx, contextEndpoint, endpoint)
 }
 
 // GetContextEndpoint get endpoint from context
 func GetContextEndpoint(ctx context.Context) string {
-	endpoint, _ := ctx.Value(ContextEndpoint).(string)
+	endpoint, _ := ctx.Value(contextEndpoint).(string)
 	return endpoint
 }
 
@@ -85,7 +85,7 @@ func GetContextEndpoint(ctx context.Context) string {
 func SetCacheableEndpoints(endpoints ...string) Options {
 	return func(c *Connector) error {
 		for _, endpoint := range endpoints {
-			c.cacheableEndpointStatus[endpoint] = EndpointActiveStatus
+			c.cacheableEndpointStatus[endpoint] = endpointActiveStatus
 		}
 		return nil
 	}

--- a/connectors/cache/fallback.go
+++ b/connectors/cache/fallback.go
@@ -60,6 +60,22 @@ func WithSkipWriteInvalidateEntities(entities ...dosa.DomainObject) Options {
 	}
 }
 
+// Context key used by SetCacheableEndpoints
+var (
+	// ContextEndpoint allows users to pass in calling endpoint name
+	ContextEndpoint string = "endpoint"
+)
+
+// SetCacheableEndpoints sets cacheable endpoints
+func SetCacheableEndpoints(endpoints ...string) Options {
+	return func(c *Connector) error {
+		for _, endpoint := range endpoints {
+			c.cacheableEndpoints[endpoint] = true
+		}
+		return nil
+	}
+}
+
 // NewConnector creates a fallback cache connector
 func NewConnector(origin, fallback dosa.Connector, scope metrics.Scope, entities []dosa.DomainObject, options ...Options) *Connector {
 	c := newConnector(origin, fallback, scope, encoding.NewGobEncoder(), entities)
@@ -76,12 +92,14 @@ func NewConnector(origin, fallback dosa.Connector, scope metrics.Scope, entities
 func newConnector(origin, fallback dosa.Connector, scope metrics.Scope, encoder encoding.Encoder, entities []dosa.DomainObject) *Connector {
 	bc := base.Connector{Next: origin}
 	set := createCachedEntitiesSet(entities)
+	cacheableEndpoints := make(map[string]bool)
 	return &Connector{
-		Connector:         bc,
-		fallback:          fallback,
-		encoder:           encoder,
-		cacheableEntities: set,
-		stats:             scope,
+		Connector:          bc,
+		fallback:           fallback,
+		encoder:            encoder,
+		cacheableEntities:  set,
+		cacheableEndpoints: cacheableEndpoints,
+		stats:              scope,
 	}
 }
 
@@ -91,6 +109,7 @@ type Connector struct {
 	fallback                       dosa.Connector
 	encoder                        encoding.Encoder
 	cacheableEntities              map[string]bool
+	cacheableEndpoints             map[string]bool
 	skipWriteInvalidateEntitiesMap map[string]bool
 	mux                            sync.Mutex
 	stats                          metrics.Scope
@@ -100,7 +119,7 @@ type Connector struct {
 
 // Upsert removes (invalidates) the entry from the fallback if the entity is not in the skipWriteInvalidateEntitiesMap
 func (c *Connector) Upsert(ctx context.Context, ei *dosa.EntityInfo, values map[string]dosa.FieldValue) error {
-	if c.isCacheable(ei) {
+	if c.isCacheable(ctx, ei) {
 		w := func() error {
 			return c.removeValueFromFallback(ctx, ei, createCacheKey(ei, values))
 		}
@@ -117,7 +136,7 @@ func (c *Connector) Read(ctx context.Context, ei *dosa.EntityInfo, keys map[stri
 		populateValuesWithKeys(keys, source)
 	}
 	// If we are not caching for this entity, just return
-	if !c.isCacheable(ei) {
+	if !c.isCacheable(ctx, ei) {
 		return source, sourceErr
 	}
 
@@ -169,7 +188,7 @@ func (c *Connector) write(ctx context.Context, ei *dosa.EntityInfo, keys map[str
 // Range returns range from origin, reverts to fallback if origin fails
 func (c *Connector) Range(ctx context.Context, ei *dosa.EntityInfo, columnConditions map[string][]*dosa.Condition, minimumFields []string, token string, limit int) ([]map[string]dosa.FieldValue, string, error) {
 	sourceRows, sourceToken, sourceErr := c.Next.Range(ctx, ei, columnConditions, dosa.All(), token, limit)
-	if !c.isCacheable(ei) || dosa.ErrorIsNotFound(sourceErr) {
+	if !c.isCacheable(ctx, ei) || dosa.ErrorIsNotFound(sourceErr) {
 		return sourceRows, sourceToken, sourceErr
 	}
 	cacheKey := rangeQuery{
@@ -230,7 +249,7 @@ func (c *Connector) MultiRead(ctx context.Context, ei *dosa.EntityInfo, keys []m
 		}
 	}
 
-	if dosa.ErrorIsNotFound(sourceErr) || !c.isCacheable(ei) {
+	if dosa.ErrorIsNotFound(sourceErr) || !c.isCacheable(ctx, ei) {
 		return source, sourceErr
 	}
 
@@ -289,7 +308,7 @@ func (c *Connector) MultiRead(ctx context.Context, ei *dosa.EntityInfo, keys []m
 
 // Remove deletes an entry
 func (c *Connector) Remove(ctx context.Context, ei *dosa.EntityInfo, keys map[string]dosa.FieldValue) error {
-	if c.isCacheable(ei) {
+	if c.isCacheable(ctx, ei) {
 		w := func() error {
 			return c.removeValueFromFallback(ctx, ei, createCacheKey(ei, keys))
 		}
@@ -301,7 +320,7 @@ func (c *Connector) Remove(ctx context.Context, ei *dosa.EntityInfo, keys map[st
 
 // MultiUpsert deletes the entries getting upserted from the fallback if the entity is not in the skipWriteInvalidateEntitiesMap
 func (c *Connector) MultiUpsert(ctx context.Context, ei *dosa.EntityInfo, multiValues []map[string]dosa.FieldValue) (result []error, err error) {
-	if c.isCacheable(ei) {
+	if c.isCacheable(ctx, ei) {
 		w := func() error {
 			for _, values := range multiValues {
 				_ = c.removeValueFromFallback(ctx, ei, createCacheKey(ei, values))
@@ -315,7 +334,7 @@ func (c *Connector) MultiUpsert(ctx context.Context, ei *dosa.EntityInfo, multiV
 
 // MultiRemove deletes multiple entries from the fallback
 func (c *Connector) MultiRemove(ctx context.Context, ei *dosa.EntityInfo, multiKeys []map[string]dosa.FieldValue) (result []error, err error) {
-	if c.isCacheable(ei) {
+	if c.isCacheable(ctx, ei) {
 		w := func() error {
 			for _, keys := range multiKeys {
 				_ = c.removeValueFromFallback(ctx, ei, createCacheKey(ei, keys))
@@ -413,8 +432,19 @@ func (c *Connector) shouldSkipInvalidateCacheOnWrite(ei *dosa.EntityInfo) bool {
 	return c.skipWriteInvalidateEntitiesMap[ei.Def.Name]
 }
 
-func (c *Connector) isCacheable(ei *dosa.EntityInfo) bool {
-	return c.cacheableEntities[ei.Def.Name]
+func (c *Connector) isCacheable(ctx context.Context, ei *dosa.EntityInfo) bool {
+	return c.cacheableEntities[ei.Def.Name] && c.isEndpointCacheable(ctx)
+}
+
+func (c *Connector) isEndpointCacheable(ctx context.Context) bool {
+	// Cacheable endpoints not set via. SetCacheableEndpoints
+	// return true to default behaviour
+	if len(c.cacheableEndpoints) == 0 {
+		return true
+	}
+
+	endpoint, _ := ctx.Value(ContextEndpoint).(string)
+	return c.cacheableEndpoints[endpoint]
 }
 
 func createCacheMapFromEntites(entities []dosa.DomainObject) map[string]bool {

--- a/connectors/cache/fallback.go
+++ b/connectors/cache/fallback.go
@@ -23,6 +23,7 @@ package cache
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -64,13 +65,22 @@ func WithSkipWriteInvalidateEntities(entities ...dosa.DomainObject) Options {
 var (
 	// ContextEndpoint allows users to pass in calling endpoint name
 	ContextEndpoint string = "endpoint"
+	// EndpointActiveStatus marks the endpoint as active
+	EndpointActiveStatus bool = true
 )
 
 // SetCacheableEndpoints sets cacheable endpoints
 func SetCacheableEndpoints(endpoints ...string) Options {
 	return func(c *Connector) error {
 		for _, endpoint := range endpoints {
-			c.cacheableEndpoints[endpoint] = true
+			fmt.Print("!!!!!!!!!!!!!!!!!1111")
+			fmt.Print("!!!!!!!!!!!!!!!!!1111")
+			fmt.Print("!!!!!!!!!!!!!!!!!1111")
+			fmt.Printf("SetCacheableEndpoints Setting Endpoint: %s", endpoint)
+			fmt.Print("!!!!!!!!!!!!!!!!!1111")
+			fmt.Print("!!!!!!!!!!!!!!!!!1111")
+			fmt.Print("!!!!!!!!!!!!!!!!!1111")
+			c.cacheableEndpointStatus[endpoint] = EndpointActiveStatus
 		}
 		return nil
 	}
@@ -92,14 +102,14 @@ func NewConnector(origin, fallback dosa.Connector, scope metrics.Scope, entities
 func newConnector(origin, fallback dosa.Connector, scope metrics.Scope, encoder encoding.Encoder, entities []dosa.DomainObject) *Connector {
 	bc := base.Connector{Next: origin}
 	set := createCachedEntitiesSet(entities)
-	cacheableEndpoints := make(map[string]bool)
+	cacheableEndpointStatus := make(map[string]bool)
 	return &Connector{
-		Connector:          bc,
-		fallback:           fallback,
-		encoder:            encoder,
-		cacheableEntities:  set,
-		cacheableEndpoints: cacheableEndpoints,
-		stats:              scope,
+		Connector:               bc,
+		fallback:                fallback,
+		encoder:                 encoder,
+		cacheableEntities:       set,
+		cacheableEndpointStatus: cacheableEndpointStatus,
+		stats:                   scope,
 	}
 }
 
@@ -109,7 +119,7 @@ type Connector struct {
 	fallback                       dosa.Connector
 	encoder                        encoding.Encoder
 	cacheableEntities              map[string]bool
-	cacheableEndpoints             map[string]bool
+	cacheableEndpointStatus        map[string]bool
 	skipWriteInvalidateEntitiesMap map[string]bool
 	mux                            sync.Mutex
 	stats                          metrics.Scope
@@ -439,12 +449,19 @@ func (c *Connector) isCacheable(ctx context.Context, ei *dosa.EntityInfo) bool {
 func (c *Connector) isEndpointCacheable(ctx context.Context) bool {
 	// Cacheable endpoints not set via. SetCacheableEndpoints
 	// return true to default behaviour
-	if len(c.cacheableEndpoints) == 0 {
+	if len(c.cacheableEndpointStatus) == 0 {
 		return true
 	}
 
 	endpoint, _ := ctx.Value(ContextEndpoint).(string)
-	return c.cacheableEndpoints[endpoint]
+	fmt.Print("!!!!!!!!!!!!!!!!!222")
+	fmt.Print("!!!!!!!!!!!!!!!!!222")
+	fmt.Print("!!!!!!!!!!!!!!!!!222")
+	fmt.Printf("isEndpointCacheable Checking Endpoint: %s", endpoint)
+	fmt.Print("!!!!!!!!!!!!!!!!!222")
+	fmt.Print("!!!!!!!!!!!!!!!!!222")
+	fmt.Print("!!!!!!!!!!!!!!!!!222")
+	return c.cacheableEndpointStatus[endpoint]
 }
 
 func createCacheMapFromEntites(entities []dosa.DomainObject) map[string]bool {

--- a/connectors/cache/fallback_test.go
+++ b/connectors/cache/fallback_test.go
@@ -1139,11 +1139,18 @@ func TestCacheableEntities(t *testing.T) {
 // Test setting cacheable endpoints
 func TestCacheableEndpoints(t *testing.T) {
 	c := NewConnector(memory.NewConnector(), memory.NewConnector(), nil, nil)
-	assert.Len(t, c.cacheableEndpoints, 0)
+	assert.Len(t, c.cacheableEndpointStatus, 0)
 
 	endpoints := []string{"getEaterPromotions", "getPromotionsForStores"}
 	c = NewConnector(memory.NewConnector(), memory.NewConnector(), nil, nil, SetCacheableEndpoints(endpoints...))
-	assert.Len(t, c.cacheableEndpoints, 2)
+	assert.Len(t, c.cacheableEndpointStatus, 2)
+
+    // Test context key setters and getters
+    for _, endpoint := range endpoints {
+        ctx := context.Background()
+        ctx = SetContextEndpoint(ctx, endpoint)
+        assert.Equal(t, GetContextEndpoint(ctx), endpoint)
+    }
 }
 
 func TestWriteKeyValueToFallback(t *testing.T) {

--- a/connectors/cache/fallback_test.go
+++ b/connectors/cache/fallback_test.go
@@ -1136,6 +1136,16 @@ func TestCacheableEntities(t *testing.T) {
 	assert.Len(t, set, 1)
 }
 
+// Test setting cacheable endpoints
+func TestCacheableEndpoints(t *testing.T) {
+	c := NewConnector(memory.NewConnector(), memory.NewConnector(), nil, nil)
+	assert.Len(t, c.cacheableEndpoints, 0)
+
+	endpoints := []string{"getEaterPromotions", "getPromotionsForStores"}
+	c = NewConnector(memory.NewConnector(), memory.NewConnector(), nil, nil, SetCacheableEndpoints(endpoints...))
+	assert.Len(t, c.cacheableEndpoints, 2)
+}
+
 func TestWriteKeyValueToFallback(t *testing.T) {
 	connector := NewConnector(memory.NewConnector(), memory.NewConnector(), nil, nil)
 	err := connector.writeKeyValueToFallback(context.TODO(), testEi, "a", nil)

--- a/connectors/cache/fallback_test.go
+++ b/connectors/cache/fallback_test.go
@@ -1145,12 +1145,12 @@ func TestCacheableEndpoints(t *testing.T) {
 	c = NewConnector(memory.NewConnector(), memory.NewConnector(), nil, nil, SetCacheableEndpoints(endpoints...))
 	assert.Len(t, c.cacheableEndpointStatus, 2)
 
-    // Test context key setters and getters
-    for _, endpoint := range endpoints {
-        ctx := context.Background()
-        ctx = SetContextEndpoint(ctx, endpoint)
-        assert.Equal(t, GetContextEndpoint(ctx), endpoint)
-    }
+	// Test context key setters and getters
+	for _, endpoint := range endpoints {
+		ctx := context.Background()
+		ctx = SetContextEndpoint(ctx, endpoint)
+		assert.Equal(t, GetContextEndpoint(ctx), endpoint)
+	}
 }
 
 func TestWriteKeyValueToFallback(t *testing.T) {


### PR DESCRIPTION
1. We are using existing 'methodName' context already being set and used in EPG
2. Create initialization function to be called as contructor options
3. New configuration defaults to NO-OP if config is not set or empty else is enforced