### PR TITLE
Split isCacheable check for read and write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## v3.4.27 (unreleased)
- - Nothing changed yet
+ - Add separate fallback cache config checks for read and writes
 
 ## v3.4.26 (2020-05-29)
  - Add cache configuration per endpoint in fallback cache


### PR DESCRIPTION
1. Since we now allow cache configuration per endpoint and per entity,
we split the cache checks to two checks
2. The reads checks both the endpoint and entity to decide to cache in
fallback
3. The writes checks only the entity to decide to invalidate the cache