### PR TITLE
Allow a field's max-size to be specified in the entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## v3.4.30 (unreleased)
- - Nothing changed yet.
- 
+ - Plumb through FieldTag into the YARPC connector.
+ - Add field tag "maxlen" to define the max. size of a field.
+
 ## v3.4.29 (2020-06-05)
  - Make fallback cache Scan API call connector Scan API instead of Range
 

--- a/connectors/cache/fallback.go
+++ b/connectors/cache/fallback.go
@@ -114,7 +114,7 @@ func newConnector(origin, fallback dosa.Connector, scope metrics.Scope, encoder 
 		encoder:                 encoder,
 		cacheableEntities:       set,
 		cacheableEndpointStatus: cacheableEndpointStatus,
-		stats: scope,
+		stats:                   scope,
 	}
 }
 

--- a/connectors/cache/fallback.go
+++ b/connectors/cache/fallback.go
@@ -114,7 +114,7 @@ func newConnector(origin, fallback dosa.Connector, scope metrics.Scope, encoder 
 		encoder:                 encoder,
 		cacheableEntities:       set,
 		cacheableEndpointStatus: cacheableEndpointStatus,
-		stats:                   scope,
+		stats: scope,
 	}
 }
 

--- a/connectors/yarpc/helpers.go
+++ b/connectors/yarpc/helpers.go
@@ -197,6 +197,18 @@ func RPCTagsFromClientTags(tags map[string]string) []*dosarpc.FieldTag {
 	return rpcTags
 }
 
+// RPCTagsToClientTags converts thrift tags to a map.
+func RPCTagsToClientTags(rpcTags []*dosarpc.FieldTag) map[string]string {
+	if len(rpcTags) == 0 {
+		return nil
+	}
+	tags := map[string]string{}
+	for _, t := range rpcTags {
+		tags[*t.Name] = *t.Value
+	}
+	return tags
+}
+
 // PrimaryKeyToThrift converts the dosa primary key to the thrift primary key type
 func PrimaryKeyToThrift(key *dosa.PrimaryKey) *dosarpc.PrimaryKey {
 	ck := make([]*dosarpc.ClusteringKey, len(key.ClusteringKeys))
@@ -300,7 +312,7 @@ func FromThriftToEntityDefinition(ed *dosarpc.EntityDefinition) *dosa.EntityDefi
 		fields[i] = &dosa.ColumnDefinition{
 			Name: colName,
 			Type: RPCTypeToClientType(*v.Type),
-			// TODO Tag
+			Tags: RPCTagsToClientTags(v.Tags),
 		}
 	}
 

--- a/connectors/yarpc/helpers.go
+++ b/connectors/yarpc/helpers.go
@@ -185,6 +185,18 @@ func RPCTypeToClientType(t dosarpc.ElemType) dosa.Type {
 	panic("bad type")
 }
 
+// RPCTagsFromClientTags converts tags to the RPC version.
+func RPCTagsFromClientTags(tags map[string]string) []*dosarpc.FieldTag {
+	rpcTags := make([]*dosarpc.FieldTag, 0, len(tags))
+	for k, v := range tags {
+		name := k
+		value := v
+		ft := dosarpc.FieldTag{Name: &name, Value: &value}
+		rpcTags = append(rpcTags, &ft)
+	}
+	return rpcTags
+}
+
 // PrimaryKeyToThrift converts the dosa primary key to the thrift primary key type
 func PrimaryKeyToThrift(key *dosa.PrimaryKey) *dosarpc.PrimaryKey {
 	ck := make([]*dosarpc.ClusteringKey, len(key.ClusteringKeys))
@@ -234,7 +246,8 @@ func entityDefToThrift(ed *dosa.EntityDefinition) *dosarpc.EntityDefinition {
 	fd := make(map[string]*dosarpc.FieldDesc, len(ed.Columns))
 	for _, column := range ed.Columns {
 		rpcType := RPCTypeFromClientType(column.Type)
-		fd[column.Name] = &dosarpc.FieldDesc{Type: &rpcType}
+		rpcTags := RPCTagsFromClientTags(column.Tags)
+		fd[column.Name] = &dosarpc.FieldDesc{Type: &rpcType, Tags: rpcTags}
 		cols = append(cols, column.Name)
 	}
 

--- a/connectors/yarpc/helpers.go
+++ b/connectors/yarpc/helpers.go
@@ -258,8 +258,7 @@ func entityDefToThrift(ed *dosa.EntityDefinition) *dosarpc.EntityDefinition {
 	fd := make(map[string]*dosarpc.FieldDesc, len(ed.Columns))
 	for _, column := range ed.Columns {
 		rpcType := RPCTypeFromClientType(column.Type)
-		rpcTags := RPCTagsFromClientTags(column.Tags)
-		fd[column.Name] = &dosarpc.FieldDesc{Type: &rpcType, Tags: rpcTags}
+		fd[column.Name] = &dosarpc.FieldDesc{Type: &rpcType, Tags: RPCTagsFromClientTags(column.Tags)}
 		cols = append(cols, column.Name)
 	}
 

--- a/connectors/yarpc/helpers_test.go
+++ b/connectors/yarpc/helpers_test.go
@@ -143,6 +143,7 @@ var testEntityDefinition = &dosa.EntityDefinition{
 		{
 			Name: stringKeyField,
 			Type: dosa.String,
+			Tags: map[string]string{"maxlen": "255"},
 		},
 		{
 			Name: int64KeyField,
@@ -160,6 +161,7 @@ var testEntityDefinition = &dosa.EntityDefinition{
 		{
 			Name: blobField,
 			Type: dosa.Blob,
+			Tags: map[string]string{"maxlen": "1000"},
 		},
 		{
 			Name: timestampField,
@@ -176,6 +178,7 @@ var testEntityDefinition = &dosa.EntityDefinition{
 		{
 			Name: stringField,
 			Type: dosa.String,
+			Tags: map[string]string{"maxlen": "100"},
 		},
 		{
 			Name: int64Field,

--- a/entity.go
+++ b/entity.go
@@ -171,9 +171,7 @@ type ColumnDefinition struct {
 	Name      string // normalized column name
 	Type      Type
 	IsPointer bool // used by client only to indicate whether this field is pointer
-	// TODO: change as need to support tags like pii, etc
-	// currently it's in the form of a map from tag name to (optional) tag value
-	Tags map[string]string
+	Tags      map[string]string
 }
 
 // Clone returns a deep copy of ColumnDefinition

--- a/entity_parser.go
+++ b/entity_parser.go
@@ -508,10 +508,14 @@ func parseField(typ Type, isPointer bool, name string, tagstr string) (*ColumnDe
 // Split a string that looks like " key1 = value1, key2=value2 , key3=value3 " into a key-value map. No
 // special characters are allowed, alphanumeric only.
 func getTags(tagstr string) (map[string]string, error) {
-	tags := map[string]string{}
-
 	// Remove all whitespace and split by commas.
-	sections := strings.Split(strings.Replace(tagstr, " ", "", -1), ",")
+	tagstr = strings.Replace(tagstr, " ", "", -1)
+	if tagstr == "" {
+		return nil, nil
+	}
+
+	tags := map[string]string{}
+	sections := strings.Split(tagstr, ",")
 
 	// Ensure each section is of the form name=value.
 	for _, s := range sections {

--- a/entity_parser.go
+++ b/entity_parser.go
@@ -486,7 +486,7 @@ func parseFieldTag(structField reflect.StructField, dosaAnnotation string) (*Col
 
 // The only accepted tags here are "name" and "maxlen". The value of "name" is normalized.
 func parseField(typ Type, isPointer bool, name string, tagstr string) (*ColumnDefinition, error) {
-	origName = name
+	origName := name
 	tags, err := getTags(tagstr)
 	if err != nil {
 		return nil, err

--- a/entity_parser.go
+++ b/entity_parser.go
@@ -486,6 +486,7 @@ func parseFieldTag(structField reflect.StructField, dosaAnnotation string) (*Col
 
 // The only accepted tags here are "name" and "maxlen". The value of "name" is normalized.
 func parseField(typ Type, isPointer bool, name string, tagstr string) (*ColumnDefinition, error) {
+	origName = name
 	tags, err := getTags(tagstr)
 	if err != nil {
 		return nil, err
@@ -499,14 +500,14 @@ func parseField(typ Type, isPointer bool, name string, tagstr string) (*ColumnDe
 		case "maxlen":
 			// No action needed.
 		default:
-			return nil, errors.Errorf("invalid dosa field tag '%s'", tag)
+			return nil, errors.Errorf("invalid dosa field tag '%s' on field '%s'", tag, origName)
 		}
 	}
 
 	// Normalize the name, and remove any "name" tag from the map.
 	name, err = NormalizeName(name)
 	if err != nil {
-		return nil, errors.Wrapf(err, "invalid dosa field tag '%s'", name)
+		return nil, errors.Wrapf(err, "invalid dosa field tag '%s' on field '%s'", name, origName)
 	}
 	delete(tags, "name")
 

--- a/entity_parser_key_parser_test.go
+++ b/entity_parser_key_parser_test.go
@@ -612,7 +612,7 @@ func TestEntityParse(t *testing.T) {
 				PartitionKeys:  []string{"ok"},
 				ClusteringKeys: nil,
 			},
-			Error: "unknown unit d in duration",
+			Error: `unknown unit "d" in duration`,
 			ETL:   EtlOff,
 			TTL:   NoTTL(),
 		},

--- a/entity_parser_test.go
+++ b/entity_parser_test.go
@@ -21,11 +21,9 @@
 package dosa
 
 import (
-	"testing"
-
-	"time"
-
 	"io"
+	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -605,6 +603,53 @@ func TestParensBalanced(t *testing.T) {
 	assert.False(t, parensBalanced(")("))
 	assert.False(t, parensBalanced("(()))"))
 	assert.False(t, parensBalanced("((()())"))
+}
+
+func TestGetTags(t *testing.T) {
+	testCases := []struct {
+		tag string
+		exp string
+		err string
+	}{
+		{
+			tag: "",
+			exp: "{}",
+		},
+		{
+			tag: "a=b",
+			exp: "{a: b}",
+		},
+		{
+			tag: "a=b,c=d",
+			exp: "{a: b, c: d}",
+		},
+		{
+			tag: " a=b , c=d",
+			exp: "{a: b, c: d}",
+		},
+		{
+			tag: "a = b,c = d ",
+			exp: "{a: b, c: d}",
+		},
+		{
+			tag: "c",
+			err: "unable to parse 'c'",
+		},
+		{
+			tag: "a=b=c",
+			err: "unable to parse 'a=b=c'",
+		},
+	}
+	for _, tc := range testCases {
+		tags, err := getTags(tc.tag)
+		if tc.err == "" {
+			assert.Nil(t, err)
+			assert.Equal(t, tc.exp, deterministicPrintMap(tags))
+		} else {
+			assert.NotNil(t, err)
+			assert.Contains(t, err.Error(), tc.err)
+		}
+	}
 }
 
 /*

--- a/entity_parser_test.go
+++ b/entity_parser_test.go
@@ -633,11 +633,11 @@ func TestGetTags(t *testing.T) {
 		},
 		{
 			tag: "c",
-			err: "unable to parse 'c'",
+			err: "invalid dosa field tag 'c'",
 		},
 		{
 			tag: "a=b=c",
-			err: "unable to parse 'a=b=c'",
+			err: "invalid dosa field tag 'a=b=c'",
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
A field in an entity may define the max size by using the `maxlen` tag. Example:

```
   UserName string `dosa:"maxlen=100,name=db_user_name"`
```

However most of this diff is just sending the entity tags into the YARPC connection. (I don't know why the implementation was never completed.)
