### PR TITLE
[Bugfix] Return the error only if it is not nil

### DIFF
--- a/cmd/dosa/scopemd.go
+++ b/cmd/dosa/scopemd.go
@@ -50,7 +50,7 @@ func (c *ScopeList) Execute(args []string) error {
 	defer shutdownMDClient(client)
 
 	var scopes []string
-	if scopes, err = c.getScopes(client); err == nil {
+	if scopes, err = c.getScopes(client); err != nil {
 		return err
 	}
 	for _, sp := range scopes {


### PR DESCRIPTION
The scope list command seems to never print the list because of this bug.